### PR TITLE
Memory leak fix

### DIFF
--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -19,7 +19,7 @@
 import unicorn as uc
 import capstone as cs
 from struct import unpack
-from rainbow.rainbow import rainbowBase
+from rainbow.rainbow import rainbowBase, HookWeakMethod
 from rainbow.color_functions import color
 
 
@@ -53,7 +53,7 @@ class rainbow_cortexm(rainbowBase):
         # block hook rather than a code fetch hook
         self.map_space(0xfffffff0, 0xffffffff)
 
-        self.emu.hook_add(uc.UC_HOOK_INTR, self.intr_hook)
+        self.emu.hook_add(uc.UC_HOOK_INTR, HookWeakMethod(self.intr_hook))
 
     def reset_stack(self):
         self.emu.reg_write(uc.arm_const.UC_ARM_REG_SP, self.STACK_ADDR)

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -19,7 +19,7 @@
 
 import math
 import os
-
+import weakref
 import capstone as cs
 import colorama
 import lief
@@ -30,6 +30,25 @@ from pygments.lexers import NasmLexer
 
 from rainbow.color_functions import color
 from rainbow.loaders import load_selector
+
+
+class HookWeakMethod:
+    """
+    Class to pass instance method callbacks to unicorn with weak referencing to
+    prevent circular dependencies.
+
+    Circular dependencies blocks the GC to clean the rainbowBase at the correct
+    time, and this causes memory troubles...
+
+    We cannot use directly weakref.WeakMethod since __call__ does not execute
+    the method, but returns it. This class does call the method when __call__
+    is executed.
+    """
+    def __init__(self, method):
+        self.method = weakref.WeakMethod(method)
+
+    def __call__(self, *args, **kwargs):
+        self.method()(*args, **kwargs)
 
 
 class rainbowBase:
@@ -70,6 +89,11 @@ class rainbowBase:
 
         # Take into account another leakage model
         self.sca_HD = sca_HD
+
+    def __del__(self):
+        # Unmap all memory regions.
+        for start, end, _ in self.emu.mem_regions():
+            self.emu.mem_unmap(start, end - start + 1)
 
     def trace_reset(self):
         self.reg_leak = None
@@ -209,19 +233,25 @@ class rainbowBase:
         self.map_space(*self.STACK)
 
         ## Add hooks
-        self.mem_unmapped_hook = self.emu.hook_add(uc.UC_HOOK_MEM_UNMAPPED, self.unmapped_hook)
-        self.block_hook = self.emu.hook_add(uc.UC_HOOK_BLOCK, self.block_handler)
+        self.mem_unmapped_hook = self.emu.hook_add(uc.UC_HOOK_MEM_UNMAPPED,
+            HookWeakMethod(self.unmapped_hook))
+        self.block_hook = self.emu.hook_add(uc.UC_HOOK_BLOCK,
+            HookWeakMethod(self.block_handler))
         if sca_mode:
             if (self.sca_HD):
-                self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE, self.sca_code_traceHD)
+                self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
+                    HookWeakMethod(self.sca_code_traceHD))
             else:
-                self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE, self.sca_code_trace)
+                self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
+                    HookWeakMethod(self.sca_code_trace))
             self.tm_hook = self.emu.hook_add(
-                uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE, self.sca_trace_mem
-            )
+                uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE,
+                HookWeakMethod(self.sca_trace_mem))
         else:
-            self.code_hook = self.emu.hook_add(uc.UC_HOOK_CODE, self.code_trace)
-            self.mem_access_hook = self.emu.hook_add( uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE, self.trace_mem)
+            self.code_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
+                HookWeakMethod(self.code_trace))
+            self.mem_access_hook = self.emu.hook_add( uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE,
+                HookWeakMethod(self.trace_mem))
 
     def remove_hooks(self):
         self.emu.hook_del(self.mem_access_hook)


### PR DESCRIPTION
Added unicorn memory release in rainbowBase finalizer, and removed some
circular references when hooking unicorn, which were preventing the
Garbage Collector from doing its job.