### PR TITLE
Cleanup thumb hacks in loader

### DIFF
--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -59,11 +59,11 @@ class rainbow_arm(rainbowBase):
 
     def block_handler(self, uci, address, size, user_data):
         # Thumb execution state bit is bit 5 in CPSR
-        thumb_bit = self["cpsr"] & 0x20
+        thumb_bit = (self["cpsr"]>>5) & 1
         if thumb_bit == 0:
             # switch disassembler to ARM mode
             self.disasm.mode = cs.CS_MODE_ARM
         else:
             self.disasm.mode = cs.CS_MODE_THUMB
 
-        self.base_block_handler(address)
+        self.base_block_handler(address | thumb_bit)

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -71,7 +71,7 @@ class rainbow_cortexm(rainbowBase):
         self['control'] = 0
 
         # TODO: handle other software-triggered exceptions (like bkpt)
-        self["pc"] = self.functions["SVC_Handler"] | 1
+        self['pc'] = self.functions["SVC_Handler"] | 1
         return False 
 
     def start(self, begin, end, timeout=0, count=0):
@@ -86,7 +86,7 @@ class rainbow_cortexm(rainbowBase):
             is_unpriv = (address >> 3) & 1
             self['control'] = (is_psp << 1) | is_unpriv
 
-            sp = self["sp"]
+            sp = self['sp']
             nvic_stack_bytes = self[sp:sp+32]
             nvic_stack = unpack('8I', nvic_stack_bytes)
 
@@ -94,7 +94,9 @@ class rainbow_cortexm(rainbowBase):
                 self[reg] = nvic_stack[i]
 
             self['ipsr'] = 0
-            self["sp"] = sp + 32
+            self['sp'] = sp + 32
             return True
 
-        self.base_block_handler(address)
+        # In a Cortex M, all code is in thumb mode
+        # So all function addresses are odd
+        self.base_block_handler(address | 1)

--- a/rainbow/loaders/elfloader.py
+++ b/rainbow/loaders/elfloader.py
@@ -51,9 +51,9 @@ def elfloader(elf_file, emu, verbose=False):
     for r in elffile.relocations:
         if r.symbol.is_function:
             if r.symbol.value == 0:
-                rsv = r.address - (r.address & 1)
+                rsv = r.address
             else:
-                rsv = r.symbol.value - (r.symbol.value & 1)
+                rsv = r.symbol.value
             emu.functions[r.symbol.name] = rsv
             if verbose:
                 print(f"Relocating {r.symbol.name} at {r.address:x} to {rsv:x}")
@@ -67,7 +67,7 @@ def elfloader(elf_file, emu, verbose=False):
             while tmpn in emu.functions:
                 c += 1
                 tmpn = f.name + str(c)
-            emu.functions[tmpn] = (f.address >> 1) << 1
+            emu.functions[tmpn] = f.address
     except:
         pass
 
@@ -76,7 +76,7 @@ def elfloader(elf_file, emu, verbose=False):
         if i.type == lief.ELF.SYMBOL_TYPES.FUNC:
             try:
                 tmpn = i.name
-                addr = (i.value >> 1) << 1 # failsafe for arm thumb
+                addr = i.value
                 if emu.functions[tmpn] != addr:
                     c = 0
                     while tmpn in emu.functions.keys():


### PR DESCRIPTION
- Remove SLB clearing of symbols addresses in ELF loader, which leads to incorrect results in x86/x64 binaries
- handle thumb_bit in base block handler based on CPSR register