### PR TITLE
Fix #15

### DIFF
--- a/examples/HW_analysis/pin_compare.py
+++ b/examples/HW_analysis/pin_compare.py
@@ -32,10 +32,6 @@ def show_nicv(values, traces, nr_digits=4):
     t = TraceBatchContainer(
         traces,
         values,
-        leakage_processing=lambda x: np.array(
-            [hamming(i) for i in x], dtype=np.uint
-        )
-        + np.random.normal(0, 0.5, len(x)),
     )
 
     s = Session(t)

--- a/examples/HW_analysis/pin_compare.py
+++ b/examples/HW_analysis/pin_compare.py
@@ -44,10 +44,10 @@ def show_nicv(values, traces, nr_digits=4):
     # s.add_engines([NicvEngine('a'+str(i), lambda v,z=i:v[z], range(9)) for i in range(nr_digits)])
 
     ## Difference leakage
-    s.add_engines([NicvEngine('a'+str(i), lambda v,z=i:np.int8(v[z]) - np.int8(STORED_PIN[z]), range(-9,8)) for i in range(nr_digits)])
+    s.add_engines([NicvEngine('a'+str(i), lambda v,z=i:9+np.int8(v[z]) - np.int8(ord(STORED_PIN[z])), range(17)) for i in range(nr_digits)])
 
     ## below is a variant on the carry bit
-    # s.add_engines([NicvEngine('c'+str(i), lambda v,z=i:v[z]>int(STORED_PIN[z]), range(16)) for i in range(nr_digits)])
+    # s.add_engines([NicvEngine('c'+str(i), lambda v,z=i:int(v[z]>ord(STORED_PIN[z])), range(2)) for i in range(nr_digits)])
 
     s.run()
 
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     for i in range(N):
         input_pin = "".join(random.choice("123456789") for _ in range(len(STORED_PIN)))
         comparePin(e, input_pin, STORED_PIN)
-        values.append([ord(x) - ord("1") for x in input_pin + STORED_PIN])
+        values.append([ord(x) for x in input_pin + STORED_PIN])
         traces.append(e.sca_values_trace.copy())
 
     print("Using Lascar to get an NICV")

--- a/examples/HW_analysis/pin_fault.py
+++ b/examples/HW_analysis/pin_fault.py
@@ -82,11 +82,7 @@ e['lr'] = 0xaaaaaaaa
 
 e.start(e.functions['storage_containsPin'], 0xaaaaaaaa)
 
-# list(map(print, e.sca_address_trace))
-
 trace = np.array(e.sca_values_trace, dtype=np.uint8)
 fault_trace = trace.max() - np.array(fault_trace, dtype=np.uint8)[:trace.shape[0]] * trace.max() 
-# crash_trace = -trace.max() + np.array(crash_trace, dtype=np.uint8)[:trace.shape[0]] * trace.max()
 
-# viewer(e.sca_address_trace, np.array([trace, fault_trace, crash_trace]))
-viewer(e.sca_address_trace, np.array([trace, fault_trace]), highlight=1)
+viewer(e.sca_address_trace, np.array([trace, fault_trace]))


### PR DESCRIPTION
- `range(-9,8)` min value was [converted to a `uint32`](https://github.com/Ledger-Donjon/lascar/blob/master/lascar/engine/partitioner_engine.py#L73) in lascar, which made it try to allocate a 16GB buffer. Avoid this problem by providing a positive range by offsetting the observed difference
- Numba complains about not being able to convert a char like "1" into an int, so perform this conversion explicitly
- Remove HW preprocessing of traces as now the default tracer [does it already](https://github.com/Ledger-Donjon/rainbow/blob/6d8a8dfcfa1cfc9d7891a7543473bb35be08cc36/rainbow/tracers.py#L7)