### PR TITLE
Provide APIs for stubbing

### DIFF
--- a/examples/ledger_ctf2/ripped.py
+++ b/examples/ledger_ctf2/ripped.py
@@ -63,10 +63,9 @@ def main_func(inputt):
     # to 'strtol' to dispatch one byte at a time
     def strtol(em):
         em["eax"] = next(inp)
-        return True
 
     # Tell the emulator that we redefined this function
-    e.stubbed_functions["strtol"] = strtol
+    e.hook_bypass("strtol", strtol)
 
     # In order to attack this binary efficiently,
     # we need the 'rand' function to output 0 in the first
@@ -78,9 +77,8 @@ def main_func(inputt):
     def rand(em):
         # em["rax"] = randval
         em["rax"] = 0
-        return True
 
-    e.stubbed_functions["rand"] = rand
+    e.hook_bypass("rand", rand)
 
     # First part : retrieves the input and resets the scheduling
     ret = e.start(e.functions["main"], 0x1038)
@@ -96,7 +94,7 @@ def main_func(inputt):
         return True
 
     # This needs to be done again to point to the new function
-    e.stubbed_functions["rand"] = rand
+    e.hook_bypass("rand", rand)
 
     # Here we start at 0x10ba so that we skip the binary's self crc-checking
     # although it would work because we did not modify the binary, we would

--- a/examples/ledger_ctf2/ripped2.py
+++ b/examples/ledger_ctf2/ripped2.py
@@ -8,10 +8,6 @@ from binascii import unhexlify
 # We just force them to return 0
 def time(em):
     em["rax"] = 0
-    return True
-
-def srand(em):
-    return True
 
 def clock_gettime(em):
     em["rax"] = 0
@@ -22,9 +18,14 @@ def rand(em):
     return True
 
 
-e = rainbow_x64(sca_mode=True, local_vars=globals())
+e = rainbow_x64(sca_mode=True)
 e.load("ctf2", typ=".elf")
 e.mem_trace = 1
+
+e.hook_bypass("time", time)
+e.hook_bypass("srand")
+e.hook_bypass("clock_gettime", clock_gettime)
+e.hook_bypass("rand", rand)
 
 def main_func(inputt):
     e[0xd037a0:0xd037a0+16] = 0
@@ -37,9 +38,8 @@ def main_func(inputt):
 
     def strtol(em):
         em["rax"] = next(inp)
-        return True
 
-    e.stubbed_functions["strtol"] = strtol
+    e.hook_bypass("strtol", strtol)
 
     e.start(0xca9, 0x1038)
     print('', end='') # Here to avoid some obscure race condition in unicorn

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -420,6 +420,31 @@ class rainbowBase:
                 adr, size, ins, op_str = self.disassemble_single(address, size)
                 self.print_asmline(adr, ins, op_str)
 
+    def hook_prolog(self, name, fn):
+        """ Add a call to function 'fn' when 'name' is called during execution. After executing 'fn, execution resumes into 'name' """
+        if name not in self.functions.keys():
+            raise Exception(f"'{name}' could not be found.")
+
+        def to_hook(x):
+            fn(x)
+            return False 
+
+        self.stubbed_functions[name] = to_hook 
+
+    def hook_bypass(self, name, fn=None):
+        """ Add a call to function 'fn' when 'name' is called during execution. After executing 'fn', execution returns to the caller """
+        if name not in self.functions.keys():
+            raise Exception(f"'{name}' could not be found.")
+
+        if fn is None:
+            fn = lambda x:x
+
+        def to_hook(x):
+            fn(x)
+            return True 
+
+        self.stubbed_functions[name] = to_hook 
+
     def return_force(self):
         """ Performs a simulated function return """
         raise NotImplementedError


### PR DESCRIPTION
Provides two new functions that ease the process of hooking onto a function:

- `rainbow.hook_prolog(name, pyfunc)` hooks a python function to the given emulated function and resumes normal execution
- `rainbow.hook_bypass(name, pyfunc)` does the same but returns to the caller

`hook_bypass` can be called without a `pyfunc`, in which case calling the emuated function will be skipped.

If `name` is not a valid function name in the currently loaded binary, both functions will raise an exception.