### PR TITLE
Filter ELF sections to support LIEF 0.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "unicorn",
         "capstone>=4.0.0",
-        "lief>=0.9.0",
+        "lief>=0.10.0",
         "intelhex",
         "colorama",
         "pygments",


### PR DESCRIPTION
Add support of LIEF 0.12. This makes rainbow.loaders.elfloader load only PROGBITS sections that are marked as ALLOC.