### PR TITLE
Add rainbow_stm32 device with RNG

### DIFF
--- a/rainbow/devices/__init__.py
+++ b/rainbow/devices/__init__.py
@@ -16,4 +16,4 @@
 #
 # Copyright 2019 Victor Servant, Ledger SAS
 
-from .stm32 import rainbow_stm32f215
+from .stm32 import rainbow_stm32, rainbow_stm32f215, rainbow_stm32l431

--- a/rainbow/devices/stm32.py
+++ b/rainbow/devices/stm32.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -16,18 +16,52 @@
 #
 # Copyright 2019 Victor Servant, Ledger SAS
 
+import random
+
 import unicorn as uc
-import capstone as cs
-import pickle
 
-from binascii import hexlify
-
-from rainbow.generics import rainbow_cortexm
-from rainbow.color_functions import color
+from ..generics import rainbow_cortexm
 
 
-class rainbow_stm32f215(rainbow_cortexm):
+class rainbow_stm32(rainbow_cortexm):
+    """STM32 generic device
 
+    STMicroelectronics STM32 shares most peripherals addresses accross the family.
+    """
+
+    RNG_BASE_ADDR = 0x50060800
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Map RNG peripheral (Random Number Generator)
+        self.map_space(self.RNG_BASE_ADDR, self.RNG_BASE_ADDR + 0xb)
+        self.emu.hook_add(
+            uc.UC_HOOK_MEM_READ,
+            self.rng_sr_read,
+            begin=self.RNG_BASE_ADDR + 0x4,
+            end=self.RNG_BASE_ADDR + 0x4,
+        )
+        self.emu.hook_add(
+            uc.UC_HOOK_MEM_READ,
+            self.rng_dr_read,
+            begin=self.RNG_BASE_ADDR + 0x8,
+            end=self.RNG_BASE_ADDR + 0x8,
+        )
+
+    def rng_sr_read(self, _uci, _access, address, _size, _value, _user_data):
+        """Hook called before RNG status register is read"""
+        self[address] = 0x1  # data ready
+
+    def rng_dr_read(self, _uci, _access, address, _size, _value, _user_data):
+        """Hook called before RNG data register is read
+
+        Please feel free to override me to implement custom random values.
+        """
+        self[address] = random.randint(0, 2**32 - 1)
+
+
+class rainbow_stm32f215(rainbow_stm32):
     FLASH = (0x00000000, 0x1FFFFFFF)
     RAM = (0x20000000, 0x3FFFFFFF)
     FSMC = (0xA0000000, 0xBFFFFFFF)
@@ -58,10 +92,10 @@ class rainbow_stm32f215(rainbow_cortexm):
         self.map_space(*self.INTERNAL)
 
 
-class rainbow_stm32l431(rainbow_cortexm):
+class rainbow_stm32l431(rainbow_stm32):
     def __init__(self, trace=True, sca_mode=False, local_vars={}):
         super().__init__(trace, sca_mode)
         import pkg_resources
         regs_pickle = pkg_resources.resource_filename(
-            __name__, '/stm32l4x1.pickle')
+            __name__, "/stm32l4x1.pickle")
         self.load_other_regs_from_pickle(regs_pickle)


### PR DESCRIPTION
This implements `rainbow_stm32` (new base class for `rainbow_stm32f215`, `rainbow_stm32l431`).

This enables us to add a generic RNG device for STM32 family.
To implement custom RNG behavior, users can override `rng_dr_read` method.