### PR TITLE
Add LRU caches for performance improvements

### DIFF
--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -271,12 +271,12 @@ class rainbowBase:
         self.block_hook = self.emu.hook_add(uc.UC_HOOK_BLOCK,
             HookWeakMethod(self.block_handler))
         if self.sca_mode:
-            if (self.sca_HD):
+            if self.sca_HD:
                 self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
-                    HookWeakMethod(self.sca_code_traceHD))
+                    regs_hd_sum_trace, self)
             else:
                 self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
-                    HookWeakMethod(self.sca_code_trace))
+                    regs_hw_sum_trace, self)
             self.tm_hook = self.emu.hook_add(
                 uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE,
                 HookWeakMethod(self.sca_trace_mem))
@@ -362,12 +362,6 @@ class rainbowBase:
             .strip("\n")
         )
         print("\n" + color("YELLOW", f"{adr:8X}  ") + line, end=";")
-
-    def sca_code_trace(self, _uci, address, size, data):
-        regs_hw_sum_trace(self, address, size, data)
-
-    def sca_code_traceHD(self, uci, address, size, data):
-        regs_hd_sum_trace(self, address, size, data)
 
     def code_trace(self, uci, address, size, data):
         """ 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -18,11 +18,10 @@
 
 
 import math
-import os
 import weakref
+from typing import Tuple
 import capstone as cs
 import colorama
-import lief
 import unicorn as uc
 from pygments import highlight
 from pygments.formatters import TerminalFormatter as formatter
@@ -330,13 +329,20 @@ class rainbowBase:
                 val = color("CYAN", f"{val:8x}")
                 print(f"  {val} <- [{addr}]", end=" ")
 
-    def disassemble_single(self, addr, size):
-        """ Disassemble a single instruction at address """
+    def disassemble_single(self, addr: int, size: int) -> Tuple[int, int, str, str]:
+        """Disassemble a single instruction using Capstone lite
+
+        This returns the address, size, mnemonic, and operands of the
+        instruction at the specified address and size (in bytes).
+
+        If you want more information, you should use disassemble_single_detailed
+        method, but is 30% slower according to Capstone documentation.
+        """
         instruction = self.emu.mem_read(addr, size)
         return next(self.disasm.disasm_lite(bytes(instruction), addr, 1))
 
-    def disassemble_single_detailed(self, addr, size):
-        """ Disassemble a single instruction at addr """
+    def disassemble_single_detailed(self, addr: int, size: int) -> cs.CsInsn:
+        """Disassemble a single instruction using Capstone"""
         instruction = self.emu.mem_read(addr, 2 * size)
         return next(self.disasm.disasm(bytes(instruction), addr, 1))
 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -30,7 +30,7 @@ from pygments.lexers import NasmLexer
 
 from .color_functions import color
 from .loaders import load_selector
-from .tracers import regs_hw_sum_trace
+from .tracers import regs_hd_sum_trace, regs_hw_sum_trace
 
 
 class HookWeakMethod:
@@ -367,27 +367,7 @@ class rainbowBase:
         regs_hw_sum_trace(self, address, size, data)
 
     def sca_code_traceHD(self, uci, address, size, data):
-        """
-        Hook that traces modified register values in side-channel mode.
-
-        Capstone 4's 'regs_access' method is used to find out which registers are explicitly modified by an instruction.
-        Once found, the information is stored in self.reg_leak to be stored at the next instruction, once the unicorn engine actually performed the current instruction.
-        """
-        if self.trace:
-            if self.reg_leak is not None:
-                for x in self.reg_leak[1]:
-                    if x not in self.TRACE_DISCARD:
-                        self.sca_address_trace.append(self.reg_leak[0])
-                        self.sca_values_trace.append(self.RegistersBackup[self.reg_map[x]] ^ uci.reg_read(self.reg_map[x]))
-                        self.RegistersBackup[self.reg_map[x]] = uci.reg_read(self.reg_map[x])
-
-            self.reg_leak = None
-
-            ins = self.disassemble_single_detailed(address, size)
-            _regs_read, regs_written = ins.regs_access()
-            if len(regs_written) > 0:
-                self.reg_leak = (f"{address:8X} {ins.mnemonic:<6}  {ins.op_str}",list(map(ins.reg_name, regs_written))
-                )
+        regs_hd_sum_trace(self, address, size, data)
 
     def code_trace(self, uci, address, size, data):
         """ 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -28,8 +28,9 @@ from pygments import highlight
 from pygments.formatters import TerminalFormatter as formatter
 from pygments.lexers import NasmLexer
 
-from rainbow.color_functions import color
-from rainbow.loaders import load_selector
+from .color_functions import color
+from .loaders import load_selector
+from .tracers import regs_hw_sum_trace
 
 
 class HookWeakMethod:
@@ -362,10 +363,9 @@ class rainbowBase:
         )
         print("\n" + color("YELLOW", f"{adr:8X}  ") + line, end=";")
 
-    def sca_code_trace(self, uci, address, size, data):
-        from .tracers import regs_hw_sum_trace
+    def sca_code_trace(self, _uci, address, size, data):
         regs_hw_sum_trace(self, address, size, data)
-          
+
     def sca_code_traceHD(self, uci, address, size, data):
         """
         Hook that traces modified register values in side-channel mode.

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -404,7 +404,7 @@ class rainbowBase:
             while True:
                 s = input("Press Enter to continue, or Input an address and a size to display an address: ")
 
-                if s is '':
+                if s == '':
                     break
                 try:
                     address = eval("0x"+s.split(" ")[0])

--- a/rainbow/tracers.py
+++ b/rainbow/tracers.py
@@ -1,15 +1,58 @@
+# This file is part of rainbow
+#
+# rainbow is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+#
+# Copyright 2020 Victor Servant, Ledger SAS
+
+import functools
+from typing import List, Tuple
+import capstone as cs
+
 from .utils import hw
 
-def regs_hw_sum_trace(rbw, address, size, data):
+
+# Least-recently used cache for register access extraction
+@functools.lru_cache(maxsize=4096)
+def registers_accessed_by_instruction(insn: cs.CsInsn) -> Tuple[List[int], List[int]]:
+    """Return read and written registers by a single instruction
+
+    Registers are represented with Capstone identifiers which mostly maps to
+    Unicorn identifiers.
+    """
+    return insn.regs_access()
+
+
+def regs_hw_sum_trace(rbw, address: int, size: int, _data):
+    """Trace written registers Hamming weight
+
+    For each instruction, this tracer sums the Hamming weight of all written
+    registers.
+
+    This tracer is hooked by default if sca_mode=True and sca_HD=False.
+    You may hook it with Unicorn as an `uc.UC_HOOK_CODE` hook.
+    """
     ins = rbw.reg_leak
     if ins is not None:
-      _, regs_written = ins.regs_access()
-      v = sum(hw(rbw.emu.reg_read(rbw.reg_map[ins.reg_name(i)])) for i in regs_written)
+        _, regs_written = registers_accessed_by_instruction(ins)
+        v = sum(hw(rbw.emu.reg_read(r)) for r in regs_written)
 
-      rbw.sca_address_trace.append( f"{address:8X} {ins.mnemonic:<6}  {ins.op_str}" )
-      rbw.sca_values_trace.append(v)
+        rbw.sca_address_trace.append(f"{ins.address:8X} {ins.mnemonic:<6}  {ins.op_str}")
+        rbw.sca_values_trace.append(v)
 
     rbw.reg_leak = rbw.disassemble_single_detailed(address, size)
+
 
 def wb_regs_trace(rbw, address, size, data):
     """One point per register value, and filter out uninteresting register accesses"""
@@ -23,6 +66,6 @@ def wb_regs_trace(rbw, address, size, data):
     rbw.reg_leak = None
 
     ins = rbw.disassemble_single_detailed(address, size)
-    _regs_read, regs_written = ins.regs_access()
+    _regs_read, regs_written = registers_accessed_by_instruction(ins)
     if len(regs_written) > 0:
-        rbw.reg_leak = (ins, regs_written) 
+        rbw.reg_leak = (ins, regs_written)


### PR DESCRIPTION
A first step towards https://github.com/Ledger-Donjon/rainbow/issues/6

I am using a TVLA script on a firmware running Rust `aes` crate to benchmark:
 * Before: 4.34 traces/s
 * **[Add LRU cache on Capstone calls](https://github.com/Ledger-Donjon/rainbow/pull/24/commits/db654030294e8e5f261953cb07768a734562c6dc)[](https://github.com/aiooss-ledger)**: 7.54 traces/s
 * **[Add LRU cache to get written registers](https://github.com/Ledger-Donjon/rainbow/pull/24/commits/0b5e3eee1d18070cbebe3aadcad92d0226936e4a)**: 11.12 traces/s
 * **[Import regs_hw_sum_trace outside of sca_code_trace](https://github.com/Ledger-Donjon/rainbow/pull/24/commits/533c119194351de17a828367561852630787a24a)**: 12.56 traces/s