### PR TITLE
Draft: Remove unused imports in rainbow.utils

### DIFF
--- a/rainbow/utils/__init__.py
+++ b/rainbow/utils/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -15,8 +15,6 @@
 #
 #
 # Copyright 2019 Victor Servant, Ledger SAS
-
-from rainbow.utils.plot.plot import plot
 
 HWT = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3,
 4, 4, 5, 4, 5, 5, 6, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6,

--- a/rainbow/utils/plot/interface.py
+++ b/rainbow/utils/plot/interface.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -17,8 +17,6 @@
 # Copyright 2019 Victor Servant, Ledger SAS
 
 from PyQt5 import QtWidgets as qt
-import PyQt5.QtCore as qtc
-import numpy as np
 from vispy import scene, color
 from .plot import plot
 

--- a/rainbow/utils/plot/plot.py
+++ b/rainbow/utils/plot/plot.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -19,7 +19,6 @@
 import numpy as np
 from vispy import scene
 from vispy import color
-from vispy import visuals
 
 # Starting from https://gist.github.com/yhql/70c3e59019cb73ec83870e946166b95f
 


### PR DESCRIPTION
This enables the user to get a side-channel trace without having to install PyQt5.

Before this patch, importing `rainbow.utils.hw` caused to import `rainbow.utils.plot.plot` which requires `pyqt5`.

TODO: check that no-one is importing `rainbow.utils.plot` directly.