### PR TITLE
Pass all arguments to parent class

### DIFF
--- a/examples/HW_analysis/pin_compare.py
+++ b/examples/HW_analysis/pin_compare.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     N = 500
 
     print("Setting up emulator")
-    e = rainbow_stm32(sca_mode=True, local_vars=globals())
+    e = rainbow_stm32(sca_mode=True)
     e.load("trezor.elf")
 
     print("Generating", N, "traces")

--- a/examples/ledger_ctf2/ripped.py
+++ b/examples/ledger_ctf2/ripped.py
@@ -23,7 +23,12 @@ def srand(em):
 
 # Set up a x64 emulator in side-channel mode (no text output) and
 # pass the previous functions to the redefined functions dictionary
-e = rainbow_x64(sca_mode=True, local_vars=globals())
+e = rainbow_x64(sca_mode=True)
+e.stubbed_functions = {
+    "time": time,
+    "clock_gettime": clock_gettime,
+    "srand": srand,
+}
 
 # load the elf
 e.load("ctf2", typ=".elf")

--- a/rainbow/devices/stm32.py
+++ b/rainbow/devices/stm32.py
@@ -69,13 +69,13 @@ class rainbow_stm32f215(rainbow_stm32):
     INTERNAL = (0xE0000000, 0xFFFFFFFF)
     STACK_ADDR = RAM[1]
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.stubbed_functions = local_vars
 
-        self.setup_step(sca_mode)
+        self.setup_step()
 
-    def setup_step(self, sca_mode):
+    def setup_step(self):
         import pkg_resources
 
         ## Get register dictionary (dumped from .svd file)
@@ -93,8 +93,8 @@ class rainbow_stm32f215(rainbow_stm32):
 
 
 class rainbow_stm32l431(rainbow_stm32):
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         import pkg_resources
         regs_pickle = pkg_resources.resource_filename(
             __name__, "/stm32l4x1.pickle")

--- a/rainbow/devices/stm32.py
+++ b/rainbow/devices/stm32.py
@@ -69,10 +69,8 @@ class rainbow_stm32f215(rainbow_stm32):
     INTERNAL = (0xE0000000, 0xFFFFFFFF)
     STACK_ADDR = RAM[1]
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stubbed_functions = local_vars
-
         self.setup_step()
 
     def setup_step(self):
@@ -93,7 +91,7 @@ class rainbow_stm32f215(rainbow_stm32):
 
 
 class rainbow_stm32l431(rainbow_stm32):
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         import pkg_resources
         regs_pickle = pkg_resources.resource_filename(

--- a/rainbow/generics/aarch64.py
+++ b/rainbow/generics/aarch64.py
@@ -29,8 +29,8 @@ class rainbow_aarch64(rainbowBase):
     INTERNAL_REGS = [f"x{i}" for i in range(30)]
     TRACE_DISCARD = []
 
-    def __init__(self, trace=True, sca_mode=False, local_vars=[]):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM64, uc.UC_MODE_ARM)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM64, cs.CS_MODE_ARM)
         self.disasm.detail = True
@@ -44,8 +44,8 @@ class rainbow_aarch64(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.arm64_const, 'UC_ARM64_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
-        
+        self.setup()
+
         self.reset_stack()
 
     def reset_stack(self):

--- a/rainbow/generics/aarch64.py
+++ b/rainbow/generics/aarch64.py
@@ -29,7 +29,7 @@ class rainbow_aarch64(rainbowBase):
     INTERNAL_REGS = [f"x{i}" for i in range(30)]
     TRACE_DISCARD = []
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM64, uc.UC_MODE_ARM)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM64, cs.CS_MODE_ARM)
@@ -43,7 +43,6 @@ class rainbow_aarch64(rainbowBase):
         known_regs = [i[len('UC_ARM64_REG_'):] for i in dir(uc.arm64_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.arm64_const, 'UC_ARM64_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -29,7 +29,7 @@ class rainbow_arm(rainbowBase):
     INTERNAL_REGS = ["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "pc", "lr"]
     TRACE_DISCARD = []
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM, uc.UC_MODE_ARM)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM, cs.CS_MODE_ARM)
@@ -43,7 +43,6 @@ class rainbow_arm(rainbowBase):
         known_regs = [i[len('UC_ARM_REG_'):] for i in dir(uc.arm_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.arm_const, 'UC_ARM_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -29,8 +29,8 @@ class rainbow_arm(rainbowBase):
     INTERNAL_REGS = ["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "pc", "lr"]
     TRACE_DISCARD = []
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM, uc.UC_MODE_ARM)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM, cs.CS_MODE_ARM)
         self.disasm.detail = True
@@ -44,8 +44,8 @@ class rainbow_arm(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.arm_const, 'UC_ARM_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
-    
+        self.setup()
+
         self.reset_stack()
 
     def reset_stack(self):

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -30,8 +30,8 @@ class rainbow_cortexm(rainbowBase):
     INTERNAL_REGS = ["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "sp", "cpsr", "pc", "lr"]
     TRACE_DISCARD = []
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM, uc.UC_MODE_THUMB | uc.UC_MODE_MCLASS)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM, cs.CS_MODE_THUMB | cs.CS_MODE_MCLASS)
         self.disasm.detail = True
@@ -45,7 +45,7 @@ class rainbow_cortexm(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.arm_const, 'UC_ARM_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
+        self.setup()
 
         self.reset_stack()
         # Force mapping of those addresses so that

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -30,7 +30,7 @@ class rainbow_cortexm(rainbowBase):
     INTERNAL_REGS = ["r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "sp", "cpsr", "pc", "lr"]
     TRACE_DISCARD = []
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_ARM, uc.UC_MODE_THUMB | uc.UC_MODE_MCLASS)
         self.disasm = cs.Cs(cs.CS_ARCH_ARM, cs.CS_MODE_THUMB | cs.CS_MODE_MCLASS)
@@ -44,7 +44,6 @@ class rainbow_cortexm(rainbowBase):
         known_regs = [i[len('UC_ARM_REG_'):] for i in dir(uc.arm_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.arm_const, 'UC_ARM_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/m68k.py
+++ b/rainbow/generics/m68k.py
@@ -29,8 +29,8 @@ class rainbow_m68k(rainbowBase):
     INTERNAL_REGS = [f"d{i}" for i in range(8)] + [f"a{i}" for i in range(8)] + ["pc"]
     TRACE_DISCARD = []
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_M68K, uc.UC_MODE_BIG_ENDIAN)
         self.disasm = cs.Cs(cs.CS_ARCH_M68K, cs.CS_MODE_M68K_000)
         self.disasm.detail = True
@@ -44,7 +44,7 @@ class rainbow_m68k(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.m68k_const, 'UC_M68K_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
+        self.setup()
 
         self.reset_stack()
 

--- a/rainbow/generics/m68k.py
+++ b/rainbow/generics/m68k.py
@@ -29,7 +29,7 @@ class rainbow_m68k(rainbowBase):
     INTERNAL_REGS = [f"d{i}" for i in range(8)] + [f"a{i}" for i in range(8)] + ["pc"]
     TRACE_DISCARD = []
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_M68K, uc.UC_MODE_BIG_ENDIAN)
         self.disasm = cs.Cs(cs.CS_ARCH_M68K, cs.CS_MODE_M68K_000)
@@ -43,7 +43,6 @@ class rainbow_m68k(rainbowBase):
         known_regs = [i[len('UC_M68K_REG_'):] for i in dir(uc.m68k_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.m68k_const, 'UC_M68K_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/x64.py
+++ b/rainbow/generics/x64.py
@@ -29,7 +29,7 @@ class rainbow_x64(rainbowBase):
     INTERNAL_REGS = ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rip"]
     TRACE_DISCARD = ["rflags"]
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_X86, uc.UC_MODE_64)
         self.disasm = cs.Cs(cs.CS_ARCH_X86, cs.CS_MODE_64)
@@ -46,7 +46,6 @@ class rainbow_x64(rainbowBase):
         known_regs = [i[len('UC_X86_REG_'):] for i in dir(uc.x86_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.x86_const, 'UC_X86_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/x64.py
+++ b/rainbow/generics/x64.py
@@ -29,8 +29,8 @@ class rainbow_x64(rainbowBase):
     INTERNAL_REGS = ["rax", "rbx", "rcx", "rdx", "rsi", "rdi", "rip"]
     TRACE_DISCARD = ["rflags"]
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_X86, uc.UC_MODE_64)
         self.disasm = cs.Cs(cs.CS_ARCH_X86, cs.CS_MODE_64)
         self.disasm.detail = True
@@ -47,7 +47,7 @@ class rainbow_x64(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.x86_const, 'UC_X86_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
+        self.setup()
 
         self.reset_stack()
 

--- a/rainbow/generics/x86.py
+++ b/rainbow/generics/x86.py
@@ -29,7 +29,7 @@ class rainbow_x86(rainbowBase):
     INTERNAL_REGS = ["eax", "ebx", "ecx", "edx", "esi", "edi", "eip", "ebp"]
     TRACE_DISCARD = ["eflags"]
 
-    def __init__(self, local_vars={}, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_X86, uc.UC_MODE_32)
         self.disasm = cs.Cs(cs.CS_ARCH_X86, cs.CS_MODE_32)
@@ -43,7 +43,6 @@ class rainbow_x86(rainbowBase):
         known_regs = [i[len('UC_X86_REG_'):] for i in dir(uc.x86_const) if '_REG' in i]
         self.reg_map = {r.lower(): getattr(uc.x86_const, 'UC_X86_REG_'+r) for r in known_regs}
 
-        self.stubbed_functions = local_vars
         self.setup()
 
         self.reset_stack()

--- a/rainbow/generics/x86.py
+++ b/rainbow/generics/x86.py
@@ -29,8 +29,8 @@ class rainbow_x86(rainbowBase):
     INTERNAL_REGS = ["eax", "ebx", "ecx", "edx", "esi", "edi", "eip", "ebp"]
     TRACE_DISCARD = ["eflags"]
 
-    def __init__(self, trace=True, sca_mode=False, local_vars={}):
-        super().__init__(trace, sca_mode)
+    def __init__(self, local_vars={}, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.emu = uc.Uc(uc.UC_ARCH_X86, uc.UC_MODE_32)
         self.disasm = cs.Cs(cs.CS_ARCH_X86, cs.CS_MODE_32)
         self.disasm.detail = True
@@ -44,7 +44,7 @@ class rainbow_x86(rainbowBase):
         self.reg_map = {r.lower(): getattr(uc.x86_const, 'UC_X86_REG_'+r) for r in known_regs}
 
         self.stubbed_functions = local_vars
-        self.setup(sca_mode)
+        self.setup()
 
         self.reset_stack()
 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -261,7 +261,7 @@ class rainbowBase:
             return True
         return False
 
-    def setup(self, sca_mode):
+    def setup(self):
         """ Sets up a stack and adds base hooks to the engine """
         ## Add a stack
         self.map_space(*self.STACK)
@@ -269,7 +269,7 @@ class rainbowBase:
         ## Add hooks
         self.block_hook = self.emu.hook_add(uc.UC_HOOK_BLOCK,
             HookWeakMethod(self.block_handler))
-        if sca_mode:
+        if self.sca_mode:
             if (self.sca_HD):
                 self.ct_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
                     HookWeakMethod(self.sca_code_traceHD))


### PR DESCRIPTION
This enables scripts to use `sca_HD=True` when using a child class of rainbow.