### PR TITLE
Pass all arguments to rainbow.start()

### DIFF
--- a/rainbow/generics/aarch64.py
+++ b/rainbow/generics/aarch64.py
@@ -50,9 +50,6 @@ class rainbow_aarch64(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.arm64_const.UC_ARM64_REG_SP, self.STACK_ADDR)
 
-    def start(self, *args, **kwargs):
-        return self._start(*args, **kwargs)
-
     def return_force(self):
         self["pc"] = self["lr"]
 

--- a/rainbow/generics/aarch64.py
+++ b/rainbow/generics/aarch64.py
@@ -50,8 +50,8 @@ class rainbow_aarch64(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.arm64_const.UC_ARM64_REG_SP, self.STACK_ADDR)
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin, end, timeout, count)
+    def start(self, *args, **kwargs):
+        return self._start(*args, **kwargs)
 
     def return_force(self):
         self["pc"] = self["lr"]

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -50,8 +50,8 @@ class rainbow_arm(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.arm_const.UC_ARM_REG_SP, self.STACK_ADDR)
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin, end, timeout, count)
+    def start(self, *args, **kwargs):
+        return self._start(*args, **kwargs)
 
     def return_force(self):
         self["pc"] = self["lr"]

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -50,9 +50,6 @@ class rainbow_arm(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.arm_const.UC_ARM_REG_SP, self.STACK_ADDR)
 
-    def start(self, *args, **kwargs):
-        return self._start(*args, **kwargs)
-
     def return_force(self):
         self["pc"] = self["lr"]
 

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -74,7 +74,7 @@ class rainbow_cortexm(rainbowBase):
         return False 
 
     def start(self, begin, *args, **kwargs):
-        return self._start(begin | 1, *args, **kwargs)
+        return super().start(begin | 1, *args, **kwargs)
 
     def return_force(self):
         self["pc"] = self["lr"]

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -73,8 +73,8 @@ class rainbow_cortexm(rainbowBase):
         self['pc'] = self.functions["SVC_Handler"] | 1
         return False 
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin | 1, end, timeout, count)
+    def start(self, begin, *args, **kwargs):
+        return self._start(begin | 1, *args, **kwargs)
 
     def return_force(self):
         self["pc"] = self["lr"]

--- a/rainbow/generics/m68k.py
+++ b/rainbow/generics/m68k.py
@@ -50,8 +50,8 @@ class rainbow_m68k(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.m68k_const.UC_M68K_REG_A7, self.STACK_ADDR)
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin, end, timeout, count)
+    def start(self, *args, **kwargs):
+        return self._start(*args, **kwargs)
 
     def return_force(self):
         ret = self[self["a7"]]

--- a/rainbow/generics/m68k.py
+++ b/rainbow/generics/m68k.py
@@ -50,9 +50,6 @@ class rainbow_m68k(rainbowBase):
     def reset_stack(self):
         self.emu.reg_write(uc.m68k_const.UC_M68K_REG_A7, self.STACK_ADDR)
 
-    def start(self, *args, **kwargs):
-        return self._start(*args, **kwargs)
-
     def return_force(self):
         ret = self[self["a7"]]
         self["a7"] += self.word_size

--- a/rainbow/generics/x64.py
+++ b/rainbow/generics/x64.py
@@ -54,8 +54,8 @@ class rainbow_x64(rainbowBase):
         self.emu.reg_write(uc.x86_const.UC_X86_REG_RBP, self.STACK_ADDR)
         self.emu.reg_write(uc.x86_const.UC_X86_REG_RSP, self.STACK_ADDR)
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin, end, timeout, count)
+    def start(self, *args, **kwargs):
+        return self._start(*args, **kwargs)
 
     def return_force(self):
         ret = self[self["rsp"]]

--- a/rainbow/generics/x64.py
+++ b/rainbow/generics/x64.py
@@ -54,9 +54,6 @@ class rainbow_x64(rainbowBase):
         self.emu.reg_write(uc.x86_const.UC_X86_REG_RBP, self.STACK_ADDR)
         self.emu.reg_write(uc.x86_const.UC_X86_REG_RSP, self.STACK_ADDR)
 
-    def start(self, *args, **kwargs):
-        return self._start(*args, **kwargs)
-
     def return_force(self):
         ret = self[self["rsp"]]
         self["rsp"] += self.word_size

--- a/rainbow/generics/x86.py
+++ b/rainbow/generics/x86.py
@@ -51,8 +51,8 @@ class rainbow_x86(rainbowBase):
         self.emu.reg_write(uc.x86_const.UC_X86_REG_EBP, self.STACK_ADDR)
         self.emu.reg_write(uc.x86_const.UC_X86_REG_ESP, self.STACK_ADDR)
 
-    def start(self, begin, end, timeout=0, count=0):
-        return self._start(begin, end, timeout, count)
+    def start(self, *args, **kwargs):
+        return self._start(*args, **kwargs)
 
     def return_force(self):
         ret = self[self["esp"]]

--- a/rainbow/generics/x86.py
+++ b/rainbow/generics/x86.py
@@ -51,9 +51,6 @@ class rainbow_x86(rainbowBase):
         self.emu.reg_write(uc.x86_const.UC_X86_REG_EBP, self.STACK_ADDR)
         self.emu.reg_write(uc.x86_const.UC_X86_REG_ESP, self.STACK_ADDR)
 
-    def start(self, *args, **kwargs):
-        return self._start(*args, **kwargs)
-
     def return_force(self):
         ret = self[self["esp"]]
         self["esp"] += self.word_size

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -246,7 +246,7 @@ class rainbowBase:
         """ Load a file into the emulator's memory """
         return load_selector(filename, self, typ, verbose=verbose)
 
-    def _start(self, begin, end, timeout=0, count=0, verbose=True):
+    def start(self, begin, end, timeout=0, count=0, verbose=True):
         """ Begin emulation """
         try:
             # Copy the original registers into the backup before starting the process

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -246,7 +246,7 @@ class rainbowBase:
         """ Load a file into the emulator's memory """
         return load_selector(filename, self, typ, verbose=verbose)
 
-    def _start(self, begin, end, timeout=None, count=None, verbose=True):
+    def _start(self, begin, end, timeout=0, count=0, verbose=True):
         """ Begin emulation """
         try:
             # Copy the original registers into the backup before starting the process


### PR DESCRIPTION
Currently I am unable to set the parameter `verbose=False` on `rainbow._start()` as this argument is not pass-though in `rainbow.start()`.

This patch proposes to rename `_start` to `start`.