### PR TITLE
Fixed region merging during memory mapping

### DIFF
--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -114,7 +114,7 @@ class rainbowBase:
 
     def map_space(self, start, end, verbose=False):
         """
-        Maps area into the unicorn emulator between a and b, or nothing if it was already mapped.
+        Maps area into the unicorn emulator between start and end, or nothing if it was already mapped.
         Only completes missing portions if there is overlapping with a previously-mapped segment
 
         The region is defined by `[start, end]`, so the region size is `end - start + 1`.
@@ -148,7 +148,7 @@ class rainbowBase:
                 (((end + 1) >> self.page_shift) << self.page_shift) + self.page_size - 1
             )
 
-        # List of overlaping or adjacent regions which must be merged.
+        # List of overlapping or adjacent regions which must be merged.
         overlaps: list[Tuple[int, bytes]] = []
         for r_start, r_end, _ in regions:
             # Region [start, end] is augmented for intersection test to detect adjacency.

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -139,8 +139,7 @@ class rainbowBase:
             return
 
         # Floor align start address
-        if start & (self.page_size - 1):
-            start = (start >> self.page_shift) << self.page_shift
+        start = (start >> self.page_shift) << self.page_shift
 
         # Ceil align end address
         if (end + 1) & (self.page_size - 1):

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,103 +1,102 @@
-import pytest
 from rainbow.generics import rainbow_arm, rainbow_x86
-import unicorn as uc
 
 tests = [
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: same map
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: included map
-            (0x1400, 0x1800), 
+            (0x1400, 0x1800),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: distinct map
-            (0x5000, 0x6000), 
+            (0x5000, 0x6000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: contiguous map above
-            (0x2000, 0x3000), 
+            (0x2000, 0x3000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: contiguous map below
-            (0x800, 0x1000), 
+            (0x800, 0x1000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: overlapping below
-            (0x1800, 0x3000), 
+            (0x1800, 0x3000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: exact overlapping below
-            (0x1800, 0x2000), 
+            (0x1800, 0x2000),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: overlapping above
-            (0x800, 0x1800), 
+            (0x800, 0x1800),
           ],
           [
-            (0x1000, 0x2000), 
+            (0x1000, 0x2000),
 
             # Test: exact overlapping above
-            (0x1000, 0x1800), 
+            (0x1000, 0x1800),
           ],
-          # [
-          #   (0x1000, 0x2000), 
-          #   (0x3000, 0x4000), 
+          [
+            (0x1000, 0x2000),
+            (0x3000, 0x4000),
 
-          #   # Test: contiguous map below and above
-          #   # Crashes
-          #   (0x2000, 0x3000), 
-          # ],
-          # [
-          #   (0x1000, 0x2000), 
+            # Test: contiguous map below and above
+            # Crashes
+            (0x2000, 0x3000),
+          ],
+          [
+            (0x1000, 0x2000),
 
-          #   # Test: inclusion of previous map
-          #   (0x800, 0x2800), 
-          # ],
-          # [
-          #   (0x1000, 0x2000), 
-          #   (0x3000, 0x4000), 
+            # Test: inclusion of previous map
+            (0x800, 0x2800),
+          ],
+          [
+            (0x1000, 0x2000),
+            (0x3000, 0x4000),
 
-          #   # Test: multiple inclusions of previous maps
-          #   (0x800, 0x5000), 
-          # ],
-          # [
-          #   (0x1000, 0x2000), 
-          #   (0x3000, 0x4000), 
+            # Test: multiple inclusions of previous maps
+            (0x800, 0x5000),
+          ],
+          [
+            (0x1000, 0x2000),
+            (0x3000, 0x4000),
 
-          #   # Test: inclusion and overlap
-          #   (0x800, 0x3800), 
-          # ],
-        ] 
+            # Test: inclusion and overlap
+            (0x800, 0x3800),
+          ],
+        ]
+
 
 def test_all_arm():
-  for test in tests:
-    emu = rainbow_arm()
+    for test in tests:
+        emu = rainbow_arm()
 
     for t in test:
-      emu.map_space(*t)
+        emu.map_space(*t)
+
 
 def test_all_x86():
-  for test in tests:
-    emu = rainbow_x86()
+    for test in tests:
+        emu = rainbow_x86()
 
     for t in test:
-      emu.map_space(*t)
-    
+        emu.map_space(*t)


### PR DESCRIPTION
Previous implementation of `map_space` has some issues :

- New region size is miscalculated when an overlap happens, probably due to : https://github.com/Ledger-Donjon/rainbow/blob/1b754455ad1798067bbbeb867dd8ec975ae04637/rainbow/rainbow.py#L166
- Algorithm fails if the new region completely includes an already mapped region (this case is not handled)
- Algorithm fails if more than 1 region overlap

Those issues have been found by trying to execute the `pin_fault.py` example, which fails on my current configuration.

The changes propose a new implementation for the region merging algorithm.
It must be verified and tested.