### PR TITLE
Run checks on pull requests

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -1,6 +1,10 @@
 name: Python package
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
GitHub Actions runs only on master. This also enables checks for pull requests.