### PR TITLE
tests: add test_init_start_del

### DIFF
--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -27,6 +27,14 @@ def test_reset(rainbow_class):
     emu.reset()
 
 
+@pytest.mark.parametrize("rainbow_class", all_devices)
+def test_init_start_del(rainbow_class):
+    """Test creating, starting and destroying a rainbow instance"""
+    emu = rainbow_class()
+    emu.start(0, 2)
+    del emu
+
+
 def test_stm32_rng():
     """Test STM32 device random number generator
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,4 +1,5 @@
 import pytest
+import unicorn
 from rainbow.generics import (
     rainbow_aarch64,
     rainbow_arm,
@@ -30,3 +31,14 @@ def test_reset(rainbow_class):
     """Test rainbow instance reset"""
     emu = rainbow_class()
     emu.reset()
+
+
+@pytest.mark.parametrize("rainbow_class", all_generics)
+def test_init_start_del(rainbow_class):
+    """Test creating, starting and destroying a rainbow instance"""
+    if rainbow_class == rainbow_cortexm and unicorn.__version__.startswith("1."):
+        pytest.skip("end of memory unmap bug with Unicorn 1")
+
+    emu = rainbow_class()
+    emu.start(0, 2)
+    del emu


### PR DESCRIPTION
These new tests verify that we are still able to delete rainbow instance after starting emulation.

Due to an Unicorn 1 `unmap` bug, one of these tests is skipped.