### PR TITLE
Add map_virtual_segments option to elfloader

### DIFF
--- a/rainbow/loaders/__init__.py
+++ b/rainbow/loaders/__init__.py
@@ -24,10 +24,10 @@ from .peloader import peloader
 LOADERS = {".hex": hexloader, ".elf": elfloader, ".so": elfloader, ".exe": peloader}
 
 
-def load_selector(filename, rainbow_instance, typ=None, entrypoint=None, verbose=False):
+def load_selector(filename, rainbow_instance, typ=None, *args, **kwargs):
     if typ is None:
         ext = os.path.splitext(filename)[1]
         loader = LOADERS[ext]
     else:
         loader = LOADERS[typ]
-    return loader(filename, rainbow_instance, verbose=verbose)
+    return loader(filename, rainbow_instance, *args, **kwargs)

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -236,9 +236,9 @@ class rainbowBase:
         if isinstance(s, slice):
             return self.emu.mem_read(s.start, s.stop - s.start)
 
-    def load(self, filename, typ=None, verbose=False):
+    def load(self, filename, *args, **kwargs):
         """ Load a file into the emulator's memory """
-        return load_selector(filename, self, typ, verbose=verbose)
+        return load_selector(filename, self, *args, **kwargs)
 
     def start(self, begin, end, timeout=0, count=0, verbose=True):
         """ Begin emulation """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 setup(
     name="rainbow",
     install_requires=[
-        "unicorn",
+        "unicorn~=1.0",
         "capstone>=4.0.0",
         "lief>=0.10.0",
         "intelhex",

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -11,6 +11,12 @@ def test_elfloader_cortexm_aes():
 
 
 def test_elfloader_trezor():
+    """Test loading HW_analysis trezor.elf with virtual segments mapped"""
+    emu = rainbow_arm()
+    emu.load("examples/HW_analysis/trezor.elf", map_virtual_segments=True, verbose=True)
+
+
+def test_elfloader_trezor():
     """Test loading HW_analysis trezor.elf"""
     emu = rainbow_arm()
     emu.load("examples/HW_analysis/trezor.elf", verbose=True)


### PR DESCRIPTION
Segments with a empty content are not loaded by the elfloader. This is problematic for ELF files containing a `.bss` segment.

This PR proposes to add a `map_virtual_segments` argument to elfloader to let user opt-in in mapping the virtual size of empty segments.