### PR TITLE
Fault injection integration and exception management

### DIFF
--- a/examples/HW_analysis/pin_fault.py
+++ b/examples/HW_analysis/pin_fault.py
@@ -59,14 +59,13 @@ for i in range(1, N):
 
     # Skip one instruction and resume emulation
     fault_skip(e)
-    ret = e.start(e["pc"], 0xaaaaaaaa, count=100, verbose=False)
-
-    if not ret:
+    try:
+      e.start(e["pc"], 0xaaaaaaaa, count=100, verbose=False)
       if result(e):
         total_faults += 1
         fault_trace[i] = 1
         print(" <-- r0 =", hex(e['r0']), end="")
-    else:
+    except RuntimeError:
       total_crashes += 1
       crash_trace[i] = 1
       print("crashed")

--- a/examples/HW_analysis/pin_fault.py
+++ b/examples/HW_analysis/pin_fault.py
@@ -49,26 +49,29 @@ for i in range(1, N):
     e['r0'] = 0xcafecafe
     e['lr'] = 0xaaaaaaaa
 
-    # Run i instructions
-    e.start(e.functions['storage_containsPin'], 0xaaaaaaaa, count=i)
-
-    # Print current instruction
-    pc = e['pc']
-    d = e.disassemble_single(pc, 4)
-    e.print_asmline(pc, d[2], d[3])
-
-    # Skip one instruction and resume emulation
-    fault_skip(e)
     try:
-      e.start(e["pc"], 0xaaaaaaaa, count=100, verbose=False)
-      if result(e):
-        total_faults += 1
-        fault_trace[i] = 1
-        print(" <-- r0 =", hex(e['r0']), end="")
+      # Run i instructions, then inject skip, then run
+      pc = e.start_and_fault(fault_skip, i, e.functions['storage_containsPin'], 0xaaaaaaaa, count=100)
     except RuntimeError:
+      # Fault crashed the emulation
       total_crashes += 1
       crash_trace[i] = 1
+      d = e.disassemble_single(pc, 4)
+      e.print_asmline(pc, d[2], d[3])
+      pc += d[1]
       print("crashed")
+      continue
+
+    # Print current instruction
+    d = e.disassemble_single(pc, 4)
+    e.print_asmline(pc, d[2], d[3])
+    pc += d[1]
+
+    if result(e):
+      # Successful fault
+      total_faults += 1
+      fault_trace[i] = 1
+      print(" <-- r0 =", hex(e['r0']), end="")
 
 print(f"\n=== {total_faults} faults found ===")
 print(f"=== {total_crashes} crashes ===")

--- a/examples/ledger_ctf2/ripped.py
+++ b/examples/ledger_ctf2/ripped.py
@@ -90,7 +90,7 @@ def main_func(inputt):
     ret = e.start(e.functions["main"], 0x1038)
 
     # sometimes execution stops if this line is not there (unicorn instance gets gc'ed ?)
-    print(ret * " ", end="")
+    print(ret, end="")
 
     # Now switch 'rand' to 7 so that we'll execute the correct AES's
     # first round

--- a/rainbow/fault_models.py
+++ b/rainbow/fault_models.py
@@ -62,8 +62,7 @@ def fault_stuck_at(value: int = 0):
 
         # We're stopped before executing the target instruction
         # so we step once and then inject the fault
-        thumb_bit = (emu["cpsr"] >> 5) & 1
-        emu.start(current_pc | thumb_bit, 0, count=1)
+        emu.start(current_pc, 0, count=1)
 
         # Inject the fault
         for reg_name in regs_written:

--- a/rainbow/fault_models.py
+++ b/rainbow/fault_models.py
@@ -40,7 +40,10 @@ def fault_skip(emu: rainbowBase):
     _, ins_size, _, _ = ins
 
     # Skip one instruction
+    # Save and restore CPSR register as Unicorn changes its value
+    cpsr = emu["cpsr"]
     emu["pc"] = current_pc + ins_size
+    emu["cpsr"] = cpsr
 
 
 def fault_stuck_at(value: int = 0):

--- a/rainbow/fault_models.py
+++ b/rainbow/fault_models.py
@@ -73,4 +73,5 @@ def fault_stuck_at(value: int = 0):
             emu[reg_name] = value
             break  # only fault one register, this could be improved later
 
+    f.__name__ = f"fault_stuck_at_0x{value:X}"
     return f

--- a/rainbow/fault_models.py
+++ b/rainbow/fault_models.py
@@ -19,7 +19,9 @@
 
 """
 This module is a collection of fault injection models.
-Each function updates the emulator state according to their model.
+A fault model is defined as a function that takes only a Rainbow instance as
+argument, then updates the emulator state according to their model and returns
+nothing.
 """
 
 from .rainbow import rainbowBase
@@ -41,30 +43,35 @@ def fault_skip(emu: rainbowBase):
     emu["pc"] = current_pc + ins_size
 
 
-def fault_stuck_at(emu: rainbowBase, value: int = 0):
-    """Inject `value` in current instruction destination register
+def fault_stuck_at(value: int = 0):
+    """Return a fault model that will inject `value` in current instruction
+    destination register
 
     This will run current instruction and increase program counter.
     Right now this only handles ARM emulation.
     """
-    # Get registers updated by current instruction
-    current_pc = emu["pc"]
-    ins = emu.disassemble_single_detailed(current_pc, 4)
-    if ins is None:
-        raise RuntimeError("Faulting an invalid instruction")
-    _, regs_written = ins.regs_access()
-    regs_written = map(ins.reg_name, regs_written)
 
-    # We're stopped before executing the target instruction
-    # so we step once and then inject the fault
-    thumb_bit = (emu["cpsr"] >> 5) & 1
-    if emu.start(current_pc | thumb_bit, 0, count=1):
-        return RuntimeError("Emulation crashed")
+    def f(emu: rainbowBase):
+        # Get registers updated by current instruction
+        current_pc = emu["pc"]
+        ins = emu.disassemble_single_detailed(current_pc, 4)
+        if ins is None:
+            raise RuntimeError("Faulting an invalid instruction")
+        _, regs_written = ins.regs_access()
+        regs_written = map(ins.reg_name, regs_written)
 
-    # Inject the fault
-    for reg_name in regs_written:
-        if reg_name.lower() in ["cpsr", "pc", "lr"]:
-            continue  # ignore
+        # We're stopped before executing the target instruction
+        # so we step once and then inject the fault
+        thumb_bit = (emu["cpsr"] >> 5) & 1
+        if emu.start(current_pc | thumb_bit, 0, count=1):
+            return RuntimeError("Emulation crashed")
 
-        emu[reg_name] = value
-        break  # only fault one register, this could be improved later
+        # Inject the fault
+        for reg_name in regs_written:
+            if reg_name.lower() in ["cpsr", "pc", "lr"]:
+                continue  # ignore
+
+            emu[reg_name] = value
+            break  # only fault one register, this could be improved later
+
+    return f

--- a/rainbow/fault_models.py
+++ b/rainbow/fault_models.py
@@ -63,8 +63,7 @@ def fault_stuck_at(value: int = 0):
         # We're stopped before executing the target instruction
         # so we step once and then inject the fault
         thumb_bit = (emu["cpsr"] >> 5) & 1
-        if emu.start(current_pc | thumb_bit, 0, count=1):
-            return RuntimeError("Emulation crashed")
+        emu.start(current_pc | thumb_bit, 0, count=1)
 
         # Inject the fault
         for reg_name in regs_written:

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -47,6 +47,11 @@ class rainbow_arm(rainbowBase):
 
         self.reset_stack()
 
+    def start(self, begin, *args, **kwargs):
+        # ARM Thumb mode case
+        thumb_bit = (self["cpsr"] >> 5) & 1
+        return super().start(begin | thumb_bit, *args, **kwargs)
+
     def reset_stack(self):
         self.emu.reg_write(uc.arm_const.UC_ARM_REG_SP, self.STACK_ADDR)
 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -275,6 +275,10 @@ class rainbowBase:
         fault_model(self)
         if "count" in kwargs:
             kwargs["count"] -= fault_index
+            if kwargs["count"] == 0:
+                return  # fault last instruction
+            elif kwargs["count"] < 0:
+                raise IndexError("fault_index must be smaller than count")
         self.start(self["pc"], *args, **kwargs)
 
     def setup(self):

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -255,11 +255,11 @@ class rainbowBase:
             return True
         return False
 
-    def start_and_fault(self, fault_model, fault_model_kwargs, fault_index: int, begin: int, *args, **kwargs):
+    def start_and_fault(self, fault_model, fault_index: int, begin: int, *args, **kwargs):
         """Begin emulation but inject a fault at specified index
 
-        This method takes 3 arguments to configure the fault, then the same
-        arguments as .start().
+        This method takes the fault model and index, then the same arguments as
+        rainbow.start().
 
         Injection faults can often led to invalid instructions which are raised
         as exceptions during emulation.
@@ -271,12 +271,11 @@ class rainbowBase:
 
             To fault the written register at the 3rd instruction to 0xFFFFFFFF::
 
-                emu.start_and_fault(fault_stuck_at, {"value": 0xFFFFFFFF}, 2,
-                                    0x01010101, 0xAAAAAAAA)
+                emu.start_and_fault(fault_stuck_at(0xFFFFFFFF), 2, 0x01010101, 0xAAAAAAAA)
         """
         kwargs_before = {**kwargs, "count": fault_index}
         self.start(begin, *args, **kwargs_before)
-        fault_model(self, **fault_model_kwargs)
+        fault_model(self)
         if "count" in kwargs:
             kwargs["count"] -= fault_index
         self.start(self["pc"], *args, **kwargs)

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -252,11 +252,12 @@ class rainbowBase:
             pc = self.emu.reg_read(uc.arm_const.UC_ARM_REG_PC)
             raise RuntimeError(f"Emulation crashed at 0x{pc:X}") from e
 
-    def start_and_fault(self, fault_model, fault_index: int, begin: int, *args, **kwargs):
+    def start_and_fault(self, fault_model, fault_index: int, begin: int, end: int, *args, **kwargs) -> int:
         """Begin emulation but inject a fault at specified index
 
         This method takes the fault model and index, then the same arguments as
-        rainbow.start().
+        rainbow.start(). It returns the memory address at which the fault was
+        applied.
 
         Injection faults can often led to invalid instructions which are raised
         as exceptions during emulation.
@@ -271,15 +272,23 @@ class rainbowBase:
                 emu.start_and_fault(fault_stuck_at(0xFFFFFFFF), 2, 0x01010101, 0xAAAAAAAA)
         """
         kwargs_before = {**kwargs, "count": fault_index}
-        self.start(begin, *args, **kwargs_before)
-        fault_model(self)
         if "count" in kwargs:
             kwargs["count"] -= fault_index
-            if kwargs["count"] == 0:
-                return  # fault last instruction
-            elif kwargs["count"] < 0:
+            if kwargs["count"] <= 0:
                 raise IndexError("fault_index must be smaller than count")
-        self.start(self["pc"], *args, **kwargs)
+
+        # Emulation before fault
+        self.start(begin, end, *args, **kwargs_before)
+        pc_fault = self['pc']
+        if pc_fault // 2 == end // 2:
+            raise IndexError("reached end of function before faulting")
+
+        # PewPew!
+        fault_model(self)
+
+        # Emulation after fault
+        self.start(self["pc"], end, *args, **kwargs)
+        return pc_fault
 
     def setup(self):
         """ Sets up a stack and adds base hooks to the engine """

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -240,7 +240,7 @@ class rainbowBase:
         """ Load a file into the emulator's memory """
         return load_selector(filename, self, typ, verbose=verbose)
 
-    def start(self, begin, end, timeout=0, count=0, verbose=True):
+    def start(self, begin, end, timeout=0, count=0) -> None:
         """ Begin emulation """
         try:
             # Copy the original registers into the backup before starting the process
@@ -249,11 +249,8 @@ class rainbowBase:
             self.emu.emu_start(begin, end, timeout=timeout, count=count)
         except Exception as e:
             self.emu.emu_stop()
-            if verbose:
-                pc = self.emu.reg_read(uc.arm_const.UC_ARM_REG_PC)
-                print(f"[*] Emulation crashed at 0x{pc:X}: {e}")
-            return True
-        return False
+            pc = self.emu.reg_read(uc.arm_const.UC_ARM_REG_PC)
+            raise RuntimeError(f"Emulation crashed at 0x{pc:X}") from e
 
     def start_and_fault(self, fault_model, fault_index: int, begin: int, *args, **kwargs):
         """Begin emulation but inject a fault at specified index

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -255,6 +255,32 @@ class rainbowBase:
             return True
         return False
 
+    def start_and_fault(self, fault_model, fault_model_kwargs, fault_index: int, begin: int, *args, **kwargs):
+        """Begin emulation but inject a fault at specified index
+
+        This method takes 3 arguments to configure the fault, then the same
+        arguments as .start().
+
+        Injection faults can often led to invalid instructions which are raised
+        as exceptions during emulation.
+
+        Example:
+            Let's consider that we have a function that we can run with::
+
+                emu.start(0x01010101, 0xAAAAAAAA)
+
+            To fault the written register at the 3rd instruction to 0xFFFFFFFF::
+
+                emu.start_and_fault(fault_stuck_at, {"value": 0xFFFFFFFF}, 2,
+                                    0x01010101, 0xAAAAAAAA)
+        """
+        kwargs_before = {**kwargs, "count": fault_index}
+        self.start(begin, *args, **kwargs_before)
+        fault_model(self, **fault_model_kwargs)
+        if "count" in kwargs:
+            kwargs["count"] -= fault_index
+        self.start(self["pc"], *args, **kwargs)
+
     def setup(self):
         """ Sets up a stack and adds base hooks to the engine """
         ## Add a stack

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 setup(
     name="rainbow",
     install_requires=[
-        "unicorn",
+        "unicorn~=1.0",
         "capstone>=4.0.0",
         "lief>=0.10.0",
         "intelhex",

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -31,6 +31,7 @@ def test_reset(rainbow_class):
 def test_init_start_del(rainbow_class):
     """Test creating, starting and destroying a rainbow instance"""
     emu = rainbow_class()
+    emu.map_space(0, 0x400)
     emu.start(0, 2)
     del emu
 
@@ -58,10 +59,10 @@ def test_stm32_rng():
     random.seed(42)
     emu = rainbow_stm32f215()
     emu.emu.mem_write(ADDRESS, CODE)
-    assert not emu.start(ADDRESS | 1, 0, count=8)
+    emu.start(ADDRESS | 1, 0, count=8)
     assert emu["r6"] == 0xA3B1799D
 
     # Try to rerun the same code again with a different seed
     random.seed(64)
-    assert not emu.start(ADDRESS | 1, 0, count=8)
+    emu.start(ADDRESS | 1, 0, count=8)
     assert emu["r6"] == 0x79E58218

--- a/tests/test_fault_models.py
+++ b/tests/test_fault_models.py
@@ -15,7 +15,7 @@ def test_fault_skip():
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
     begin = emu.functions["storage_containsPin"]
-    emu.start_and_fault(fault_skip, {}, 15, begin, 0xAAAAAAAA)
+    emu.start_and_fault(fault_skip, 15, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0xCAFECAFE and emu["pc"] == 0xAAAAAAAA
@@ -34,7 +34,7 @@ def test_fault_stuck_at_zeros():
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
     begin = emu.functions["storage_containsPin"]
-    emu.start_and_fault(fault_stuck_at, {}, 40, begin, 0xAAAAAAAA)
+    emu.start_and_fault(fault_stuck_at(), 40, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0x1 and emu["pc"] == 0xAAAAAAAA
@@ -53,7 +53,7 @@ def test_fault_stuck_at_ones():
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
     begin = emu.functions["storage_containsPin"]
-    emu.start_and_fault(fault_stuck_at, {"value": 0xFFFFFFFF}, 2, begin, 0xAAAAAAAA)
+    emu.start_and_fault(fault_stuck_at(0xFFFFFFFF), 2, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0x1 and emu["pc"] == 0xAAAAAAAA

--- a/tests/test_fault_models.py
+++ b/tests/test_fault_models.py
@@ -14,9 +14,8 @@ def test_fault_skip():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    assert not emu.start(emu.functions["storage_containsPin"], 0xAAAAAAAA, count=15)
-    fault_skip(emu)
-    assert not emu.start(emu["pc"], 0xAAAAAAAA, count=100)
+    begin = emu.functions["storage_containsPin"]
+    emu.start_and_fault(fault_skip, {}, 15, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0xCAFECAFE and emu["pc"] == 0xAAAAAAAA
@@ -34,9 +33,8 @@ def test_fault_stuck_at_zeros():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    assert not emu.start(emu.functions["storage_containsPin"], 0xAAAAAAAA, count=40)
-    fault_stuck_at(emu)
-    assert not emu.start(emu["pc"], 0xAAAAAAAA, count=100)
+    begin = emu.functions["storage_containsPin"]
+    emu.start_and_fault(fault_stuck_at, {}, 40, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0x1 and emu["pc"] == 0xAAAAAAAA
@@ -54,9 +52,8 @@ def test_fault_stuck_at_ones():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    assert not emu.start(emu.functions["storage_containsPin"], 0xAAAAAAAA, count=2)
-    fault_stuck_at(emu, 0xFFFFFFFF)
-    assert not emu.start(emu["pc"], 0xAAAAAAAA, count=100)
+    begin = emu.functions["storage_containsPin"]
+    emu.start_and_fault(fault_stuck_at, {"value": 0xFFFFFFFF}, 2, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
     assert emu["r0"] == 0x1 and emu["pc"] == 0xAAAAAAAA

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -40,5 +40,10 @@ def test_init_start_del(rainbow_class):
         pytest.skip("end of memory unmap bug with Unicorn 1")
 
     emu = rainbow_class()
-    emu.start(0, 2)
+    emu.map_space(0, 0x400)
+    if rainbow_class == rainbow_aarch64:
+        emu[0] = b"\x1f\x20\x03\xd5"  # NOP
+    if rainbow_class == rainbow_m68k:
+        emu[0] = b"\x4E\x71\x4E\x71"  # NOP;NOP
+    emu.start(0, 4)
     del emu

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -10,14 +10,14 @@ def test_hook_bypass_ctf2():
         e["rax"] = 0
 
     emu.hook_bypass("strtol", strtol)
-    assert not emu.start(0xCA9, 0xDCE)
+    emu.start(0xCA9, 0xDCE)
 
 
 def test_hook_bypass_ctf2_empty():
     emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.hook_bypass("strtol")
-    assert not emu.start(0xCA9, 0xDCE)
+    emu.start(0xCA9, 0xDCE)
 
 
 def test_hook_bypass_missing_name():

--- a/tests/test_tracers.py
+++ b/tests/test_tracers.py
@@ -27,7 +27,7 @@ def test_regs_tracer(regs_tracer):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.trace_reset()
-    assert not emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
     assert len(emu.sca_values_trace) > 0
 
 
@@ -52,7 +52,7 @@ def test_regs_tracer_discard(regs_tracer):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.trace_reset()
-    assert not emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
     assert len(emu.sca_values_trace) > 0
     trace1 = emu.sca_values_trace
 
@@ -61,7 +61,7 @@ def test_regs_tracer_discard(regs_tracer):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.trace_reset()
-    assert not emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
     assert len(emu.sca_values_trace) > 0
     trace2 = emu.sca_values_trace
     assert trace1 != trace2


### PR DESCRIPTION
This PR proposes a breaking change: `emu.start()` will now return None and raise emulator exceptions.

This adds a `start_and_fault` method to Rainbow to allow for quick and easy fault injection testing.