### PR TITLE
Unicorn 2 support

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3

--- a/rainbow/color_functions.py
+++ b/rainbow/color_functions.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -16,10 +16,19 @@
 #
 # Copyright 2019 Victor Servant, Ledger SAS
 
-import colorama
+_RST = "\u001b[0m"
+FOREGROUND_COLORS = {
+    "BLACK": "\u001b[30m",
+    "RED": "\u001b[31m",
+    "GREEN": "\u001b[32m",
+    "YELLOW": "\u001b[33m",
+    "BLUE": "\u001b[34m",
+    "MAGENTA": "\u001b[35m",
+    "CYAN": "\u001b[36m",
+    "WHITE": "\u001b[37m",
+}
 
-_RST = colorama.Fore.RESET
-
-
-def color(name, x):
-    return f"{getattr(colorama.Fore,name)}{x}{_RST}"
+def color(color_name: str, x: str) -> str:
+    """Color string `x` with color `color_name`"""
+    color_code = FOREGROUND_COLORS.get(color_name, "")
+    return f"{color_code}{x}{_RST}"

--- a/rainbow/generics/aarch64.py
+++ b/rainbow/generics/aarch64.py
@@ -19,7 +19,6 @@
 import unicorn as uc
 import capstone as cs
 from rainbow.rainbow import rainbowBase
-from rainbow.color_functions import color
 
 
 class rainbow_aarch64(rainbowBase):

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -19,7 +19,6 @@
 import unicorn as uc
 import capstone as cs
 from rainbow.rainbow import rainbowBase
-from rainbow.color_functions import color
 
 
 class rainbow_arm(rainbowBase):

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -58,6 +58,12 @@ class rainbow_cortexm(rainbowBase):
         self.emu.reg_write(uc.arm_const.UC_ARM_REG_SP, self.STACK_ADDR)
 
     def intr_hook(self, uci, intno, data):
+        # Handle ARM MMU exceptions introduced in Unicorn 2
+        # See https://github.com/unicorn-engine/unicorn/issues/1650
+        if intno == 3:
+            self.emu.emu_stop()
+            return
+
         # Hack : pretend this is all exceptions at once
         self['ipsr'] = 0xfffffff
 

--- a/rainbow/generics/cortexm.py
+++ b/rainbow/generics/cortexm.py
@@ -20,7 +20,6 @@ import unicorn as uc
 import capstone as cs
 from struct import unpack
 from rainbow.rainbow import rainbowBase, HookWeakMethod
-from rainbow.color_functions import color
 
 
 class rainbow_cortexm(rainbowBase):

--- a/rainbow/generics/m68k.py
+++ b/rainbow/generics/m68k.py
@@ -19,7 +19,6 @@
 import unicorn as uc
 import capstone as cs
 from rainbow.rainbow import rainbowBase
-from rainbow.color_functions import color
 
 
 class rainbow_m68k(rainbowBase):

--- a/rainbow/generics/x64.py
+++ b/rainbow/generics/x64.py
@@ -19,7 +19,6 @@
 import unicorn as uc
 import capstone as cs
 from rainbow.rainbow import rainbowBase
-from rainbow.color_functions import color
 
 
 class rainbow_x64(rainbowBase):

--- a/rainbow/generics/x86.py
+++ b/rainbow/generics/x86.py
@@ -19,7 +19,6 @@
 import unicorn as uc
 import capstone as cs
 from rainbow.rainbow import rainbowBase
-from rainbow.color_functions import color
 
 
 class rainbow_x86(rainbowBase):

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -91,10 +91,6 @@ class rainbowBase:
         self.sca_HD = sca_HD
 
     def __del__(self):
-        # Unmap all memory regions.
-        for start, end, _ in self.emu.mem_regions():
-            self.emu.mem_unmap(start, end - start + 1)
-
         # Calling colorama.init too many times without deinit may cause issues
         colorama.deinit()
 

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -20,9 +20,9 @@
 import functools
 import math
 import weakref
+import os
 from typing import Callable, Tuple
 import capstone as cs
-import colorama
 import unicorn as uc
 from pygments import highlight
 from pygments.formatters import TerminalFormatter as formatter
@@ -83,16 +83,14 @@ class rainbowBase:
         self.asm_hl = NasmLexer()
         self.asm_fmt = formatter(outencoding="utf-8")
 
-        colorama.init()
+        # Enable ANSI mode on Windows
+        if os.name == "nt":
+            os.system("")
 
         self.trace_reset()
 
         # Take into account another leakage model
         self.sca_HD = sca_HD
-
-    def __del__(self):
-        # Calling colorama.init too many times without deinit may cause issues
-        colorama.deinit()
 
     def trace_reset(self):
         self.reg_leak = None

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 setup(
     name="rainbow",
     install_requires=[
-        "unicorn~=1.0",
+        "unicorn>=2.0.1",
         "capstone>=4.0.0",
         "lief>=0.10.0",
         "intelhex",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "capstone>=4.0.0",
         "lief>=0.10.0",
         "intelhex",
-        "colorama",
         "pygments",
     ],
     packages=find_packages(),


### PR DESCRIPTION
Fixes https://github.com/Ledger-Donjon/rainbow/issues/39

Unicorn 2 adds new architectures such as Risc-V. `setup.py` specifies at least Unicorn 2.0.1 as it fixes some vulnerabilities:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29695
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29694
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29693
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44078

This pull request also makes all Rainbow requirements present in NixPkgs 22.11 :)