### PR TITLE
Hook functions by address

### DIFF
--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -2,7 +2,7 @@ import pytest
 from rainbow.generics import rainbow_x64
 
 
-def test_hook_bypass_ctf2():
+def test_hook_bypass_ctf2_name():
     emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
 
@@ -13,7 +13,18 @@ def test_hook_bypass_ctf2():
     emu.start(0xCA9, 0xDCE)
 
 
-def test_hook_bypass_ctf2_empty():
+def test_hook_bypass_ctf2_addr():
+    emu = rainbow_x64()
+    emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
+
+    def strtol(e):
+        e["rax"] = 0
+
+    emu.hook_bypass(2109344, strtol)
+    emu.start(0xCA9, 0xDCE)
+
+
+def test_hook_bypass_ctf2_name_empty():
     emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.hook_bypass("strtol")


### PR DESCRIPTION
This patch proposes to use function addresses rather than name internally.

This enables users to hook functions by name (like before) or address.
If multiple functions match one name, then all the functions are hooked. This helps when loading multiple files at different addresses having some common symbols.

This patch also adds a test to make sure hooking by address works.

🎧