### PR TITLE
Test on Python 3.11

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        # TODO: add windows-latest
+        os: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.11 was released on 24 Oct 2022, Rainbow should test against it.

With this PR applied, Rainbow will be tested against all active Python version (see https://endoflife.date/python).