### PR TITLE
Stub by address, not by function name

### DIFF
--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -46,6 +46,6 @@ def test_remove_hooks():
     emu.setup()
 
     emu.hook_bypass("strtol")
-    assert "strtol" in emu.stubbed_functions
+    assert 0x202fa0 in emu.stubbed_functions
     emu.remove_hooks()
-    assert "strtol" not in emu.stubbed_functions
+    assert 0x202fa0 not in emu.stubbed_functions


### PR DESCRIPTION
When using Rainbow with multiple complex binaries loaded in memory, it is common to have multiple function with the same name.

This patch proposes to change how Rainbow internally handle stubbing:

- Before: user can only stub the first function matching the name given.
- After: user can stub all function matching the name given, or a function by its address.

This also increases reproducibility of experiments conducted using Rainbow.

> **Note**
> This creates a breaking changes as `emu.stubbed_functions` will now contain function addresses.