### PR TITLE
Make colorama an optional dependency

### DIFF
--- a/rainbow/utils/color_functions.py
+++ b/rainbow/utils/color_functions.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -16,10 +16,20 @@
 #
 # Copyright 2019 Victor Servant, Ledger SAS
 
-import colorama
+_RST = "\u001b[0m"
+FOREGROUND_COLORS = {
+    "BLACK": "\u001b[30m",
+    "RED": "\u001b[31m",
+    "GREEN": "\u001b[32m",
+    "YELLOW": "\u001b[33m",
+    "BLUE": "\u001b[34m",
+    "MAGENTA": "\u001b[35m",
+    "CYAN": "\u001b[36m",
+    "WHITE": "\u001b[37m",
+}
 
-_RST = colorama.Fore.RESET
 
-
-def color(name, x):
-    return f"{getattr(colorama.Fore,name)}{x}{_RST}"
+def color(color_name: str, x: str) -> str:
+    """Color string `x` with color `color_name`"""
+    color_code = FOREGROUND_COLORS.get(color_name, "")
+    return f"{color_code}{x}{_RST}"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# This file is part of rainbow 
+# This file is part of rainbow
 #
 # rainbow is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -45,7 +45,6 @@ setup(
         "capstone>=4.0.0",
         "lief>=0.10.0",
         "intelhex",
-        "colorama",
         "pygments",
         "numpy",
         "PyQt5"


### PR DESCRIPTION
This patch proposes to remove colorama as a dependency. User can still install colorama and follow the README instructions to get colors.

This reduces maintenance cost while maintaining cross-platform compatibility for colors.