### PR TITLE
utils/color_functions: color only inside atty

### DIFF
--- a/rainbow/utils/color_functions.py
+++ b/rainbow/utils/color_functions.py
@@ -15,21 +15,39 @@
 #
 #
 # Copyright 2019 Victor Servant, Ledger SAS
+import sys
 
-_RST = "\u001b[0m"
-FOREGROUND_COLORS = {
-    "BLACK": "\u001b[30m",
-    "RED": "\u001b[31m",
-    "GREEN": "\u001b[32m",
-    "YELLOW": "\u001b[33m",
-    "BLUE": "\u001b[34m",
-    "MAGENTA": "\u001b[35m",
-    "CYAN": "\u001b[36m",
-    "WHITE": "\u001b[37m",
-}
+from pygments import highlight
+from pygments.formatters import NullFormatter, TerminalFormatter
+from pygments.lexers.asm import NasmLexer
+
+# Use colors only if tty support ANSI colors
+ASM_HL = NasmLexer()
+ASM_FMT = NullFormatter(outencoding="utf-8")
+FOREGROUND_COLORS = {}
+if sys.stdout.isatty():
+    ASM_FMT = TerminalFormatter(outencoding="utf-8")
+    FOREGROUND_COLORS = {
+        "BLACK": "\u001b[30m",
+        "RED": "\u001b[31m",
+        "GREEN": "\u001b[32m",
+        "YELLOW": "\u001b[33m",
+        "BLUE": "\u001b[34m",
+        "MAGENTA": "\u001b[35m",
+        "CYAN": "\u001b[36m",
+        "WHITE": "\u001b[37m",
+        "_RST": "\u001b[0m",
+    }
 
 
 def color(color_name: str, x: str) -> str:
     """Color string `x` with color `color_name`"""
     color_code = FOREGROUND_COLORS.get(color_name, "")
-    return f"{color_code}{x}{_RST}"
+    rst_code = FOREGROUND_COLORS.get("_RST", "")
+    return f"{color_code}{x}{rst_code}"
+
+
+def highlight_asmline(addr: int, ins: str, op_str: str):
+    """Pretty-print assembly using pygments syntax highlighting"""
+    line = highlight(f"{ins:<6}  {op_str:<20}", ASM_HL, ASM_FMT).decode().strip("\n")
+    print("\n" + color("YELLOW", f"{addr:8X}  ") + line, end=";")


### PR DESCRIPTION
Before this patch, piping rainbow output to a file would keep ANSI escape codes, making it harder to read and parse the output.

This patch moves pygments highlight function to utils.color_functions and then configures it to only output ANSI colors if isatty is true.