### PR TITLE
Handle addresses pointing to multiple symbols

### DIFF
--- a/rainbow/loaders/cleloader.py
+++ b/rainbow/loaders/cleloader.py
@@ -41,5 +41,6 @@ def cleloader(path: str, emu, ld_path=(), verbose=False, except_missing_libs=Tru
     if verbose:
         print(f"[+] Loading {len(func_symbols)} functions symbol")
     for symbol in func_symbols:
-        emu.functions[symbol.name] = symbol.rebased_addr
-        emu.function_names.update({symbol.rebased_addr: symbol.name})
+        # Map function names to all addresses they refer to, and addresses to all function names
+        emu.functions[symbol.name] = emu.functions.get(symbol.name, []) + [symbol.rebased_addr]
+        emu.function_names[symbol.rebased_addr] = emu.function_names.get(symbol.rebased_addr, []) + [symbol.name]

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -70,8 +70,8 @@ class Rainbow(abc.ABC):
     emu: Optional[uc.Uc]
     disasm: Optional[cs.Cs]
     reg_backup: List[int]
-    functions: Dict[str, int]
-    function_names: Dict[int, str]
+    functions: Dict[str, List[int]]
+    function_names: Dict[int, List[str]]
 
     # Arch. constants
     UC_ARCH: int

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -409,7 +409,7 @@ class Rainbow(abc.ABC):
     def _get_addrs(self, name_or_addr):
         if isinstance(name_or_addr, str):
             # Stub all function addresses matching this name
-            addrs = [a for a, n in self.function_names.items() if n == name_or_addr]
+            addrs = [a for a, n in self.function_names.items() if name_or_addr in n]
             if not addrs:
                 raise IndexError(f"'{name_or_addr}' could not be found.")
             return addrs

--- a/tests/test_fault_models.py
+++ b/tests/test_fault_models.py
@@ -14,7 +14,7 @@ def test_fault_skip():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    begin = emu.functions["storage_containsPin"]
+    begin = emu.functions["storage_containsPin"][0]
     emu.start_and_fault(fault_skip, 15, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
@@ -33,7 +33,7 @@ def test_fault_stuck_at_zeros():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    begin = emu.functions["storage_containsPin"]
+    begin = emu.functions["storage_containsPin"][0]
     emu.start_and_fault(fault_stuck_at(), 40, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value
@@ -52,7 +52,7 @@ def test_fault_stuck_at_ones():
     # Skip a branch inside storage_containsPin
     emu["r0"] = 0xCAFECAFE
     emu["lr"] = 0xAAAAAAAA
-    begin = emu.functions["storage_containsPin"]
+    begin = emu.functions["storage_containsPin"][0]
     emu.start_and_fault(fault_stuck_at(0xFFFFFFFF), 2, begin, 0xAAAAAAAA)
 
     # Check that the function returned a faulted value

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -10,16 +10,21 @@ def test_hook_bypass_ctf2():
     def strtol(e):
         e["rax"] = 0
 
+    emu[0xCAFE1000] = b"test"
+    emu["rdx"] = 0xCAFE1000
     emu.hook_bypass("strtol", strtol)
-    emu.start(0xCA9, 0xDCE)
+    emu.start(0x00400CA9, 0x00400DC8)
 
 
 def test_hook_bypass_ctf2_empty():
     emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.setup()
+
+    emu[0xCAFE1000] = b"test"
+    emu["rdx"] = 0xCAFE1000
     emu.hook_bypass("strtol")
-    emu.start(0xCA9, 0xDCE)
+    emu.start(0x00400CA9, 0x00400DC8)
 
 
 def test_hook_bypass_missing_name():
@@ -46,6 +51,6 @@ def test_remove_hooks():
     emu.setup()
 
     emu.hook_bypass("strtol")
-    assert 0x202fa0 in emu.stubbed_functions
+    assert 0x1648c10 in emu.stubbed_functions
     emu.remove_hooks()
-    assert 0x202fa0 not in emu.stubbed_functions
+    assert 0x1648c10 not in emu.stubbed_functions

--- a/tests/test_leakage_models.py
+++ b/tests/test_leakage_models.py
@@ -29,7 +29,7 @@ def test_regs_tracer(leakage_model, option, instr):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.reset_trace()
-    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"][0] | 1, 0)
     assert len(emu.trace) > 0
 
 
@@ -51,7 +51,7 @@ def test_regs_tracer_discard(leakage_model, instr):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.reset_trace()
-    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"][0] | 1, 0)
     assert len(emu.trace) > 0
     trace1 = emu.trace
 
@@ -60,7 +60,7 @@ def test_regs_tracer_discard(leakage_model, instr):
     emu["r0"] = key_addr
     emu["r1"] = rk_addr + 16
     emu.reset_trace()
-    emu.start(emu.functions["AES_128_keyschedule"] | 1, 0)
+    emu.start(emu.functions["AES_128_keyschedule"][0] | 1, 0)
     assert len(emu.trace) > 0
     trace2 = emu.trace
     assert trace1 != trace2


### PR DESCRIPTION
When loading ELF, an address can point to multiple symbols. An example of such case is inside `tests/test_hook.py` example.
Fix failing tests by updating the structure of `rainbow.functions` and `rainbow.function_names`.
**This is a breaking change!**