### PR TITLE
Output zero when no registers are written

### DIFF
--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -44,17 +44,22 @@ class Print(Flag):
 class TraceConfig:
     """Tracing configuration."""
 
-    def __init__(self,
-                 mem_address: Optional[LeakageModel] = None,
-                 mem_value: Optional[LeakageModel] = None,
-                 register: Optional[LeakageModel] = None,
-                 instruction: bool = False,
-                 ignored_registers: Optional[Set[str]] = None):
+    def __init__(
+        self,
+        mem_address: Optional[LeakageModel] = None,
+        mem_value: Optional[LeakageModel] = None,
+        register: Optional[LeakageModel] = None,
+        instruction: bool = False,
+        ignored_registers: Optional[Set[str]] = None,
+        only_when_registers: bool = True,
+    ):
         self.mem_address = mem_address
         self.mem_value = mem_value
         self.register = register
         self.instructions = instruction
         self.ignored_registers = ignored_registers
+        # When true, only output register leakage when at least one register is written
+        self.only_when_registers = only_when_registers
 
 
 class Rainbow(abc.ABC):
@@ -566,7 +571,7 @@ class Rainbow(abc.ABC):
             #  - last_reg_values are register values as they were before the previous instruction
             #
             # So we need to go over last_regs, get their prev values from last_reg_values and get their current values.
-            if self.last_regs:
+            if self.last_regs or not self.trace_config.only_when_registers:
                 reg_values = {r: uci.reg_read(self.REGS[r]) for r in self.last_regs}
                 leak = sum(
                     self.trace_config.register(reg_values[r], self.last_reg_values.get(r, 0)) for r in self.last_regs)

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -83,7 +83,7 @@ class Rainbow(abc.ABC):
     ENDIANNESS: str
     PC: int
 
-    last_regs: Optional[List[str]]
+    last_regs: List[str]
     last_reg_values: Optional[Dict[str, int]]
     last_address: Optional[int]
     last_value: Optional[int]
@@ -580,12 +580,9 @@ class Rainbow(abc.ABC):
             if ins is None:
                 ins = self.disassemble_single_detailed(address, size)
                 _, regs_written = ins.regs_access()
-                if regs_written:
-                    regs = list(filter(lambda r: r not in self.IGNORED_REGS and (
-                                not self.trace_config.ignored_registers or r not in self.trace_config.ignored_registers),
-                                       map(ins.reg_name, regs_written)))  # type: ignore
-                else:
-                    regs = None
+                regs = list(filter(lambda r: r not in self.IGNORED_REGS and (
+                            not self.trace_config.ignored_registers or r not in self.trace_config.ignored_registers),
+                                    map(ins.reg_name, regs_written)))  # type: ignore
 
         if self.trace_config.instructions:
             if ins is None:


### PR DESCRIPTION
Currently generated register side-channel traces does not have the same length as the number of executed instructions.
Tracing 500 `NOP` then 500 `XOR` will only generate a trace for the 500 XOR, hiding the fact that there were some NOPs.

This patch simplifies the register tracing function to print zero when no registers are written.