### PR TITLE
Speed up function stubbing system

### DIFF
--- a/examples/ledger_ctf2/ripped.py
+++ b/examples/ledger_ctf2/ripped.py
@@ -29,7 +29,7 @@ def srand(em):
 # We'd like to trace everything we can
 # - memory accesses
 # - modified registers
-e = rainbow_x64(trace_config=TraceConfig(mem_value=HammingWeight(), register=HammingWeight()), allow_stubs=True)
+e = rainbow_x64(trace_config=TraceConfig(mem_value=HammingWeight(), register=HammingWeight()))
 e.stubbed_functions = {
     "time": time,
     "clock_gettime": clock_gettime,

--- a/examples/ledger_ctf2/ripped2.py
+++ b/examples/ledger_ctf2/ripped2.py
@@ -21,7 +21,7 @@ def rand(em):
     em["rax"] = 7
 
 
-e = rainbow_x64(trace_config=TraceConfig(mem_value=Identity()), allow_stubs=True)
+e = rainbow_x64(trace_config=TraceConfig(mem_value=Identity()))
 e.load("ctf2", typ=".elf", except_missing_libs=False)
 e.setup()
 

--- a/rainbow/generics/arm.py
+++ b/rainbow/generics/arm.py
@@ -52,11 +52,12 @@ class rainbow_arm(Rainbow):
     def return_force(self):
         self["pc"] = self["lr"]
 
-    def _block_hook(self, uci, address, size, user_data):
-        if self.thumb_bit == 0:
-            # switch disassembler to ARM mode
-            self.disasm.mode = cs.CS_MODE_ARM
-        else:
-            self.disasm.mode = cs.CS_MODE_THUMB
+    def disassemble_single(self, addr: int, size: int):
+        # Switch disassembler to ARM or Thumb mode
+        self.disasm.mode = cs.CS_MODE_ARM if self.thumb_bit == 0 else cs.CS_MODE_THUMB
+        return super().disassemble_single(addr, size)
 
-        super()._block_hook(uci, address | self.thumb_bit, size, user_data)
+    def disassemble_single_detailed(self, addr: int, size: int) -> cs.CsInsn:
+        # Switch disassembler to ARM or Thumb mode
+        self.disasm.mode = cs.CS_MODE_ARM if self.thumb_bit == 0 else cs.CS_MODE_THUMB
+        return super().disassemble_single_detailed(addr, size)

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -3,7 +3,7 @@ from rainbow.generics import rainbow_x64
 
 
 def test_hook_bypass_ctf2():
-    emu = rainbow_x64(allow_stubs=True)
+    emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.setup()
 
@@ -15,7 +15,7 @@ def test_hook_bypass_ctf2():
 
 
 def test_hook_bypass_ctf2_empty():
-    emu = rainbow_x64(allow_stubs=True)
+    emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.setup()
     emu.hook_bypass("strtol")
@@ -23,14 +23,14 @@ def test_hook_bypass_ctf2_empty():
 
 
 def test_hook_bypass_missing_name():
-    emu = rainbow_x64(allow_stubs=True)
+    emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     with pytest.raises(IndexError):
         emu.hook_bypass("strtol_blabla")
 
 
 def test_hook_prolog_missing_name():
-    emu = rainbow_x64(allow_stubs=True)
+    emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
 
     def strtol(e):
@@ -41,7 +41,7 @@ def test_hook_prolog_missing_name():
 
 
 def test_remove_hooks():
-    emu = rainbow_x64(allow_stubs=True)
+    emu = rainbow_x64()
     emu.load("examples/ledger_ctf2/ctf2", typ=".elf")
     emu.setup()
 


### PR DESCRIPTION
Rainbow no longer hooks the whole memory for block execution events. This greatly improves performance as Unicorn is no longer jumping between Python and C when emulating a loop.

Remove `allow_stub` attribute as activating stubs without stubbing functions no longer slow rainbow.
`rainbow.generics` classes no longer add code to global `_block_hook` and rather properly override `disassemble_single`, which is only executed when needed (making rainbow faster!).

This change made some of my experiments 6x faster!