### PR TITLE
Fix remove_hooks dict iteration

### DIFF
--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -464,9 +464,9 @@ class Rainbow(abc.ABC):
 
     def remove_hooks(self):
         """Remove all hooked functions."""
-        for addr, hook in self.stubbed_functions.items():
+        for hook in self.stubbed_functions.values():
             self.emu.hook_del(hook)
-            del self.stubbed_functions[addr]
+        self.stubbed_functions.clear()
 
     @staticmethod
     def _print_function_hook(_uci, address: int, _size, name: str):


### PR DESCRIPTION
When running tests, the following error is raised:
```
    def remove_hooks(self):
        """Remove all hooked functions."""
>       for addr, hook in self.stubbed_functions.items():
E       RuntimeError: dictionary changed size during iteration
```

This is caused by https://github.com/Ledger-Donjon/rainbow/pull/65 (oops).

This PR proposes a trivial patch to fix the issue. With this PR, all tests are now green 🎉 