### PR TITLE
Drop explicit setup calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Load a binary:
 
 ```python
 e.load('file', typ='.elf')
-e.setup()
 ```
 
 File type is guessed on the extension when possible (.elf, .hex).
@@ -105,7 +104,6 @@ from rainbow import TraceConfig, HammingWeight
 
 e = rainbow_stm32f215(trace_config=TraceConfig(register=HammingWeight()))
 e.load('file', typ='.elf')
-e.setup()
 
 e.start(start_address)
 

--- a/examples/CortexM_AES/cortexm_aes.py
+++ b/examples/CortexM_AES/cortexm_aes.py
@@ -12,7 +12,6 @@ from visplot import plot
 
 e = rainbow_arm(trace_config=TraceConfig(register=HammingWeight()))
 e.load("aes.bin", typ=".elf")
-e.setup()
 
 
 def aes_encrypt(key, plaintext):

--- a/examples/HW_analysis/pin_compare.py
+++ b/examples/HW_analysis/pin_compare.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
     print("Setting up emulator")
     e = rainbow_stm32(trace_config=TraceConfig(register=HammingWeight(), instruction=True))
     e.load("trezor.elf")
-    e.setup()
 
     print("Generating", N, "traces")
 

--- a/examples/HW_analysis/pin_fault.py
+++ b/examples/HW_analysis/pin_fault.py
@@ -20,7 +20,6 @@ def setup_emulator(trace_config=TraceConfig()) -> rainbow_stm32:
     print("Setting up emulator")
     e = rainbow_stm32(trace_config=trace_config)
     e.load("trezor.elf")
-    e.setup()
 
     # as in the side-channel example, this is the location of the reference
     # pin in Flash

--- a/examples/OAES/OAES_x86.py
+++ b/examples/OAES/OAES_x86.py
@@ -11,7 +11,6 @@ from lascar import Session, TraceBatchContainer
 def generate_targetf():
     e = rainbow_x86(trace_config=TraceConfig(register=HammingWeight(), mem_value=Identity(), instruction=True, mem_address=Identity()))
     e.load("libnative-lib_x86.so", except_missing_libs=False)
-    e.setup()
 
     target_func = "_Z48TfcqPqf1lNhu0DC2qGsAAeML0SEmOBYX4jpYUnyT8qYWIlEqPhS_"
 

--- a/examples/SecAESSTM32/go.py
+++ b/examples/SecAESSTM32/go.py
@@ -61,7 +61,6 @@ def f_aes(e, key, input_):
 if __name__ == "__main__":
     e = rainbow_stm32f215(print_config=Print.Functions, trace_config=TraceConfig(register=HammingWeight()))
     e.load('firmware.elf')
-    e.setup()
 
     return_addr = 0
     # map it to prevent an unmapped fetch exception

--- a/examples/hacklu2009/go.py
+++ b/examples/hacklu2009/go.py
@@ -11,7 +11,6 @@ from rainbow import TraceConfig, HammingWeight
 
 e = rainbow_x86(trace_config=TraceConfig(register=HammingWeight()))
 e.load('crackme.exe', except_missing_libs=False)
-e.setup()
 
 
 def encrypt(plain):

--- a/examples/pimp_my_xor/x64_pimpmyxor.py
+++ b/examples/pimp_my_xor/x64_pimpmyxor.py
@@ -8,7 +8,6 @@ from rainbow.generics import rainbow_x64
 
 e = rainbow_x64(print_config=Print.Code)
 e.load("pimp_my_xor", typ=".elf", except_missing_libs=False)
-e.setup()
 
 # Read the obfuscated password
 hidden_string = e[0x404060 : 0x404060 + 0x2E]

--- a/rainbow/rainbow.py
+++ b/rainbow/rainbow.py
@@ -94,9 +94,6 @@ class Rainbow(abc.ABC):
     last_value: Optional[int]
     trace: List[Any]
 
-    mem_hook: Optional[int]
-    code_hook: Optional[int]
-
     def __init__(
         self,
         print_config: Print = Print(0),
@@ -125,6 +122,12 @@ class Rainbow(abc.ABC):
         self.disasm = cs.Cs(self.CS_ARCH, self.CS_MODE)
         self.disasm.detail = True
         self.map_space(*self.STACK)
+
+        # Prepare emulator hooks
+        self._emu_functions_hook: Dict[Tuple[int, str], int] = {}
+        self._emu_memory_hook: Optional[int] = None
+        self._emu_code_hook: Optional[int] = None
+        self._setup_hooks()
 
         self.reset_stack()
 
@@ -281,6 +284,7 @@ class Rainbow(abc.ABC):
 
     def start(self, begin, end, timeout=0, count=0) -> None:
         """ Begin emulation """
+        self._setup_hooks()  # update hooks if needed
         try:
             self.emu.emu_start(begin, end, timeout=timeout, count=count)
         except Exception as e:
@@ -328,31 +332,56 @@ class Rainbow(abc.ABC):
         self.start(self["pc"], end, *args, **kwargs)
         return pc_fault
 
-    def setup(self):
-        """Setup engine hooks."""
+    def _setup_hooks(self):
+        """Update engine hooks with current configuration"""
         # Hook functions calls for printing
         if self.print_config & Print.Functions:
             for addr, name in self.function_names.items():
-                self.emu.hook_add(
+                if (addr, name) in self._emu_functions_hook:
+                    continue  # already hooked
+                self._emu_functions_hook[(addr, name)] = self.emu.hook_add(
                     uc.UC_HOOK_BLOCK,
                     self._print_function_hook,
                     begin=addr,
                     end=addr,
                     user_data=name,
                 )
+            # Clear orphan function hooks
+            for (addr, name), hook in self._emu_functions_hook.items():
+                if (addr, name) not in self.function_names.items():
+                    self.emu.hook_del(hook)
+                    del self._emu_functions_hook[(addr, name)]
 
         # We need the mem hook only if we are
         # printing memory or tracing memory values or addresses.
-        if self.print_config & Print.Memory or self.trace_config.mem_value or self.trace_config.mem_address:
-            self.mem_hook = self.emu.hook_add(uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE,
-                                              HookWeakMethod(self._mem_hook))
+        if (
+            self.print_config & Print.Memory
+            or self.trace_config.mem_value
+            or self.trace_config.mem_address
+        ):
+            if self._emu_memory_hook is None:
+                self._emu_memory_hook = self.emu.hook_add(
+                    uc.UC_HOOK_MEM_READ | uc.UC_HOOK_MEM_WRITE,
+                    HookWeakMethod(self._mem_hook),
+                )
+        elif self._emu_memory_hook is not None:
+            self.emu.hook_del(self._emu_memory_hook)
 
         # We need the code hook only if we are
         # printing code or registers, tracing registers or instruction or need to handle breakpoints.
-        if self.print_config & (
-                Print.Code | Print.Registers) or self.trace_config.register or self.trace_config.instructions or self.allow_breakpoints:
-            self.code_hook = self.emu.hook_add(uc.UC_HOOK_CODE,
-                                               HookWeakMethod(self._code_hook))
+        if (
+            self.print_config & (Print.Code | Print.Registers)
+            or self.trace_config.register
+            or self.trace_config.instructions
+            or self.allow_breakpoints
+        ):
+            if self._emu_code_hook is None:
+                self._emu_code_hook = self.emu.hook_add(
+                    uc.UC_HOOK_CODE,
+                    HookWeakMethod(self._code_hook),
+                )
+        elif self._emu_code_hook is not None:
+            self.emu.hook_del(self._emu_code_hook)
 
     def remove_bkpt(self, address):
         if not self.allow_breakpoints:

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -5,7 +5,6 @@ from rainbow.generics import rainbow_x64
 def test_hook_bypass_ctf2():
     emu = rainbow_x64()
     emu.load("tests/ledger_ctf2/ctf2", typ=".elf", except_missing_libs=False)
-    emu.setup()
 
     def strtol(e):
         e["rax"] = 0
@@ -19,7 +18,6 @@ def test_hook_bypass_ctf2():
 def test_hook_bypass_ctf2_empty():
     emu = rainbow_x64()
     emu.load("tests/ledger_ctf2/ctf2", typ=".elf", except_missing_libs=False)
-    emu.setup()
 
     emu[0xCAFE1000] = b"test"
     emu["rdx"] = 0xCAFE1000
@@ -49,7 +47,6 @@ def test_hook_prolog_missing_name():
 def test_remove_hooks():
     emu = rainbow_x64()
     emu.load("tests/ledger_ctf2/ctf2", typ=".elf", except_missing_libs=False)
-    emu.setup()
 
     emu.hook_bypass("strtol")
     assert 0x1648c10 in emu.stubbed_functions

--- a/tests/test_leakage_models.py
+++ b/tests/test_leakage_models.py
@@ -16,7 +16,6 @@ def test_regs_tracer(leakage_model, option, instr):
     setattr(tr, option, leakage_model())
     emu = rainbow_arm(trace_config=tr)
     emu.load("examples/CortexM_AES/aes.bin", typ=".elf")
-    emu.setup()
 
     # Setup data
     key = bytes(range(16))
@@ -38,7 +37,6 @@ def test_regs_tracer(leakage_model, option, instr):
 def test_regs_tracer_discard(leakage_model, instr):
     emu = rainbow_arm(trace_config=TraceConfig(register=leakage_model(), instruction=instr))
     emu.load("examples/CortexM_AES/aes.bin", typ=".elf")
-    emu.setup()
 
     # Setup data
     key = bytes(range(16))


### PR DESCRIPTION
Rainbow currently requires to explicitly call `setup()` method to setup Unicorn-Engine hooks.
Because of current design, it is impossible to cleanly change hooking configuration between two emulator run.

This patch proposes to keep track of all engine hooks registered, and to remove/update them accordingly to chosen configuration. For example it is possible to start emulation, update `print_config`, then start emulation again with updated configuration. 

Because the hooking setup function can now be called multiple times without creating duplicated hooks, I propose to remove the explicit call to the `setup()` method, making Rainbow a bit easier to use.